### PR TITLE
abort timer bandaid

### DIFF
--- a/Assets/Scripts/Functional Definitions/Interaction Definitions/SectorManager.cs
+++ b/Assets/Scripts/Functional Definitions/Interaction Definitions/SectorManager.cs
@@ -158,12 +158,10 @@ public class SectorManager : MonoBehaviour
         {
             player.SetIsInteracting(true);
         }
-
-        var inCurrentSector = player && current != null &&
-                              (current.bounds.contains(player.transform.position) || player.GetIsOscillating()) && current.dimension == player.Dimension;
-
         var isBz = GetCurrentType() == Sector.SectorType.BattleZone;
         var isSiege = GetCurrentType() == Sector.SectorType.SiegeZone;
+        var inCurrentSector = player && current != null &&
+                              (current.bounds.contains(player.transform.position) || (player.GetIsOscillating() && !isBz && !isSiege)) && current.dimension == player.Dimension;
         var abortTimerFinished = abortTimer <= 1;
         var playing = (isBz && battleZone.playing) || (isSiege && siegeZone.playing);
 


### PR DESCRIPTION
sectormanager no longer checks for oscillation in battlezones or siegezones to prevent player from getting stuck in the abort timer by standing still