### PR TITLE
Fixed shellcore jittering when controlling with left mouse button

### DIFF
--- a/Assets/Scripts/Game Object Definitions/Entity Definitions/PlayerCore.cs
+++ b/Assets/Scripts/Game Object Definitions/Entity Definitions/PlayerCore.cs
@@ -144,7 +144,8 @@ public class PlayerCore : ShellCore
         if (Input.GetMouseButton(1) && !(MouseMovementVisualScript.overMinimap && Input.GetMouseButton(0)))
         {
             minimapPoint = null;
-            var delta = CameraScript.instance.GetWorldPositionOfMouse() - transform.position;
+            // The angle from center of the screen to the mouse position on screen
+            var delta = Input.mousePosition - new Vector3(Screen.width, Screen.height, 0) * 0.5f;
             return delta.normalized;
         }
 


### PR DESCRIPTION
Fixes a bug that made the Shellcore shake when controlled using left mouse button, caused by the lack of precision when getting an angle from two points in low resolution, specially when both points are in constant change.

This solution picks the angle from the center of the screen to the mouse position on the screen, and considering that the game world is highly zoomed-in, the distance between these points is way higher, and therefore we can get a finer angle from them.

Gifs from before and after:
 
![Gif of ship jittering](https://media.discordapp.net/attachments/791385282548858880/987849623173464064/jittering_ship.gif "Jittering Ship")
![Gif of ship jittering](https://media.discordapp.net/attachments/791385282548858880/987849623932653579/not_jittering_ship.gif "Not jittering Ship")