### PR TITLE
Ship builder zoom

### DIFF
--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
@@ -456,19 +456,7 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
         }
 
         // Zooming
-        if (Input.mouseScrollDelta.y != 0)
-        {
-            Transform gridTransform = GameObject.Find("Container/BuildSection/GridMask/Image").transform;
-            float oldZoom = this.zoom;
-
-            // Apply zoom
-            Zoom = Mathf.Clamp(this.zoom + Input.mouseScrollDelta.y * zoomStep, zoomMin, zoomMax);
-            
-            // Move grid to keep mouse at the same position after zooming
-            Vector3 mousePositionRelativeToGridCenter = (Input.mousePosition - gridTransform.position) / oldZoom;
-            float zoomChange = oldZoom - this.zoom;
-            gridTransform.position += mousePositionRelativeToGridCenter * zoomChange;
-        }
+        HandleZooming();
     }
 
     public void UpdateCurrentPart()
@@ -651,6 +639,23 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
             default:
                 return part.mirrored != symmetryPart.mirrored && ((part.rotation + symmetryPart.rotation) % 360 == 0);
         }
+    }
+
+    private void HandleZooming()
+    {
+        if (Input.mouseScrollDelta.y == 0)
+        {
+            return;
+        }
+    
+        float oldZoom = Zoom;
+        
+        Zoom = Mathf.Clamp(Zoom + Input.mouseScrollDelta.y * zoomStep, zoomMin, zoomMax);
+        
+        // Move grid to keep mouse at the same position after zooming
+        Vector3 mousePositionRelativeToGridCenter = (Input.mousePosition - grid.position) / oldZoom;
+        float zoomChange = oldZoom - Zoom;
+        grid.position += mousePositionRelativeToGridCenter * zoomChange;
     }
 
     public void ToggleCompact()

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
@@ -261,11 +261,6 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
 
     public EntityBlueprint.PartInfo? GetPartCursorIsOn()
     {
-        if (!isMouseOnGrid)
-        {
-            return null;
-        }
-
         foreach (ShipBuilderPart part in parts)
         {
             if (RectTransformUtility.RectangleContainsScreenPoint(part.rectTransform, Input.mousePosition))

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
@@ -452,18 +452,7 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
         }
 
         UpdateCurrentPart();
-
-        // drag grid
-        Vector2 bounds = grid.sizeDelta / 2 - grid2mask.sizeDelta / 2;
-        if (grid.GetComponent<DragDetector>().dragging
-            && Input.GetMouseButton(0) && !rotateMode && !flipped && !currentPart)
-        {
-            grid.anchoredPosition = grid2lastPos + ((Vector2)Input.mousePosition - grid2mousePos) * 2;
-            grid.anchoredPosition = new Vector2(Mathf.Max(-bounds.x, Mathf.Min(bounds.x, grid.anchoredPosition.x)),
-                Mathf.Max(-bounds.y, Mathf.Min(bounds.y, grid.anchoredPosition.y))
-            );
-        }
-
+        HandleDraggingGrid();
         HandleZooming();
     }
 
@@ -654,6 +643,15 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
         }
     }
 
+    private void HandleDraggingGrid()
+    {
+        if (grid.GetComponent<DragDetector>().dragging && Input.GetMouseButton(0) && !rotateMode && !flipped && !currentPart)
+        {
+            grid.anchoredPosition = grid2lastPos + ((Vector2)Input.mousePosition - grid2mousePos) * 2;
+            ClampGridPosition();
+        }
+    }
+
     private void HandleZooming()
     {
         if (Input.mouseScrollDelta.y == 0 || !isMouseOnGrid)
@@ -669,6 +667,18 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
         Vector3 mousePositionRelativeToGridCenter = (Input.mousePosition - grid.position) / oldZoom;
         float zoomChange = oldZoom - Zoom;
         grid.position += mousePositionRelativeToGridCenter * zoomChange;
+
+        // Make sure the player won't view beyond the grid end when zooming out
+        ClampGridPosition();
+    }
+
+    private void ClampGridPosition()
+    {
+        Vector2 bounds = (grid.sizeDelta * Zoom - grid2mask.sizeDelta) * 0.5f;
+        grid.anchoredPosition = new Vector2(
+            Mathf.Clamp(grid.anchoredPosition.x, -bounds.x, bounds.x),
+            Mathf.Clamp(grid.anchoredPosition.y, -bounds.y, bounds.y)
+        );
     }
 
     public void ToggleCompact()

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
@@ -46,6 +46,8 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
     bool clickedOnce;
     float timer;
 
+    public static bool isMouseOnGrid = false;
+
     private float zoomMax = 2.5f;
     private float zoomMin = 0.5f;
     private float zoomStep = 0.1f;
@@ -259,6 +261,11 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
 
     public EntityBlueprint.PartInfo? GetPartCursorIsOn()
     {
+        if (!isMouseOnGrid)
+        {
+            return null;
+        }
+
         foreach (ShipBuilderPart part in parts)
         {
             if (RectTransformUtility.RectangleContainsScreenPoint(part.rectTransform, Input.mousePosition))
@@ -391,6 +398,8 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
     void Update()
     {
         UpdateCompact();
+
+        isMouseOnGrid = RectTransformUtility.RectangleContainsScreenPoint(grid2mask, Input.mousePosition);
 
         if (clickedOnce)
         {
@@ -550,6 +559,11 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
     // symmetry mode enables checks based on symmetryPart - same part ID, ability ID, different mirrored
     public ShipBuilderPart FindPart(Vector2 vector, ShipBuilderPart symmetryPart, bool useBounds = false)
     {
+        if (!isMouseOnGrid)
+        {
+            return null;
+        }
+
         for (int i = parts.Count - 1; i >= 0; i--)
         {
             var origPos = transform.position;
@@ -642,15 +656,15 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
 
     private void HandleZooming()
     {
-        if (Input.mouseScrollDelta.y == 0)
+        if (Input.mouseScrollDelta.y == 0 || !isMouseOnGrid)
         {
             return;
         }
-    
+
         float oldZoom = Zoom;
-        
+
         Zoom = Mathf.Clamp(Zoom + Input.mouseScrollDelta.y * zoomStep * Zoom, zoomMin, zoomMax);
-        
+
         // Move grid to keep mouse at the same position after zooming
         Vector3 mousePositionRelativeToGridCenter = (Input.mousePosition - grid.position) / oldZoom;
         float zoomChange = oldZoom - Zoom;

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
@@ -455,7 +455,6 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
             );
         }
 
-        // Zooming
         HandleZooming();
     }
 

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
@@ -650,7 +650,7 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
     
         float oldZoom = Zoom;
         
-        Zoom = Mathf.Clamp(Zoom + Input.mouseScrollDelta.y * zoomStep, zoomMin, zoomMax);
+        Zoom = Mathf.Clamp(Zoom + Input.mouseScrollDelta.y * zoomStep * Zoom, zoomMin, zoomMax);
         
         // Move grid to keep mouse at the same position after zooming
         Vector3 mousePositionRelativeToGridCenter = (Input.mousePosition - grid.position) / oldZoom;

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
@@ -46,6 +46,11 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
     bool clickedOnce;
     float timer;
 
+    private float zoomMax = 2.5f;
+    private float zoomMin = 0.5f;
+    private float zoomStep = 0.1f;
+    private float zoom = 1.0f;
+
     public void SetMode(BuilderMode mode)
     {
         cursorMode = mode;
@@ -438,6 +443,22 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
             grid.anchoredPosition = new Vector2(Mathf.Max(-bounds.x, Mathf.Min(bounds.x, grid.anchoredPosition.x)),
                 Mathf.Max(-bounds.y, Mathf.Min(bounds.y, grid.anchoredPosition.y))
             );
+        }
+
+        // Zooming
+        if (Input.mouseScrollDelta.y != 0)
+        {
+            Transform gridTransform = GameObject.Find("Container/BuildSection/GridMask/Image").transform;
+            float oldZoom = this.zoom;
+
+            // Apply zoom
+            this.zoom = Mathf.Clamp(this.zoom + Input.mouseScrollDelta.y * zoomStep, zoomMin, zoomMax);
+            gridTransform.localScale = new Vector3(1, 1, 0) * this.zoom;
+            
+            // Move grid to keep mouse at the same position after zooming
+            Vector3 mousePositionRelativeToGridCenter = (Input.mousePosition - gridTransform.position) / oldZoom;
+            float zoomChange = oldZoom - this.zoom;
+            gridTransform.position += mousePositionRelativeToGridCenter * zoomChange;
         }
     }
 

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
@@ -49,7 +49,16 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
     private float zoomMax = 2.5f;
     private float zoomMin = 0.5f;
     private float zoomStep = 0.1f;
-    private float zoom = 1.0f;
+    private float zoom;
+    private float Zoom
+    {
+        get { return zoom; }
+        set
+        {
+            zoom = value;
+            grid.localScale = new Vector3(1, 1, 0) * value;
+        }
+    }
 
     public void SetMode(BuilderMode mode)
     {
@@ -66,6 +75,7 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
         compactMode = Screen.width == 1024;
         buildCost = 0;
         currentAbilities = new List<Ability>();
+        Zoom = 1.0f;
 
         grid.anchoredPosition = Vector2.zero;
         buildValue = 0;
@@ -452,8 +462,7 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
             float oldZoom = this.zoom;
 
             // Apply zoom
-            this.zoom = Mathf.Clamp(this.zoom + Input.mouseScrollDelta.y * zoomStep, zoomMin, zoomMax);
-            gridTransform.localScale = new Vector3(1, 1, 0) * this.zoom;
+            Zoom = Mathf.Clamp(this.zoom + Input.mouseScrollDelta.y * zoomStep, zoomMin, zoomMax);
             
             // Move grid to keep mouse at the same position after zooming
             Vector3 mousePositionRelativeToGridCenter = (Input.mousePosition - gridTransform.position) / oldZoom;

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderPart.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderPart.cs
@@ -94,32 +94,36 @@ public class ShipBuilderPart : DisplayPart, IPointerEnterHandler, IPointerExitHa
         else
         {
             image.color = (isInChain && validPos ? mainColor : mainColor - new Color(0, 0, 0, 0.5F));
-            switch (cursorScript.symmetryMode)
+
+            if (ShipBuilderCursorScript.isMouseOnGrid)
             {
-                case ShipBuilderCursorScript.SymmetryMode.X:
-                case ShipBuilderCursorScript.SymmetryMode.Y:
-                    var symVec = cursorScript.GetSymmetrizedVector(rectTransform.anchoredPosition, cursorScript.symmetryMode);
-                    var symmetryPart = cursorScript.FindPart(symVec, this);
-                    var onAxis = false;
-                    if (cursorScript.symmetryMode == ShipBuilderCursorScript.SymmetryMode.X)
-                    {
-                        onAxis = Mathf.Abs(rectTransform.anchoredPosition.y) < ShipBuilderCursorScript.stepSize;
-                    }
+                switch (cursorScript.symmetryMode)
+                {
+                    case ShipBuilderCursorScript.SymmetryMode.X:
+                    case ShipBuilderCursorScript.SymmetryMode.Y:
+                        var symVec = cursorScript.GetSymmetrizedVector(rectTransform.anchoredPosition, cursorScript.symmetryMode);
+                        var symmetryPart = cursorScript.FindPart(symVec, this);
+                        var onAxis = false;
+                        if (cursorScript.symmetryMode == ShipBuilderCursorScript.SymmetryMode.X)
+                        {
+                            onAxis = Mathf.Abs(rectTransform.anchoredPosition.y) < ShipBuilderCursorScript.stepSize;
+                        }
 
-                    if (cursorScript.symmetryMode == ShipBuilderCursorScript.SymmetryMode.X)
-                    {
-                        onAxis = Mathf.Abs(rectTransform.anchoredPosition.x) < ShipBuilderCursorScript.stepSize;
-                    }
+                        if (cursorScript.symmetryMode == ShipBuilderCursorScript.SymmetryMode.X)
+                        {
+                            onAxis = Mathf.Abs(rectTransform.anchoredPosition.x) < ShipBuilderCursorScript.stepSize;
+                        }
 
-                    if ((!symmetryPart || (symmetryPart.rectTransform.anchoredPosition - symVec).sqrMagnitude >
-                        ShipBuilderCursorScript.stepSize) && !onAxis)
-                    {
-                        image.color = FactionManager.GetFactionColor(1);
-                    }
+                        if ((!symmetryPart || (symmetryPart.rectTransform.anchoredPosition - symVec).sqrMagnitude >
+                            ShipBuilderCursorScript.stepSize) && !onAxis)
+                        {
+                            image.color = FactionManager.GetFactionColor(1);
+                        }
 
-                    break;
-                default:
-                    break;
+                        break;
+                    default:
+                        break;
+                }
             }
 
             image.material = null;


### PR DESCRIPTION
Implements zooming in ship builder, also fixes the bug that lets us select parts outside the ship builder grid mask, as it was convenient to fix.

![shipbuilder zoom finished](https://user-images.githubusercontent.com/47065615/178167063-adf48503-2772-44ff-ab5b-2673399dede9.gif)

Regarding the way `ShipBuilderCursorScript.isMouseOnGrid` gets updated:
`ShipBuilderPart` and `ShipBuilderCursorScript` have to check whether the mouse it's on the grid multiple times per frame, so we rather have a static boolean that updated only once every frame than have a method which would get called multiple times every frame for the same purpose.