### PR TITLE
Prevent background spawns when showing task dialogue

### DIFF
--- a/Assets/Scripts/Functional Definitions/Interaction Definitions/DialogueSystem.cs
+++ b/Assets/Scripts/Functional Definitions/Interaction Definitions/DialogueSystem.cs
@@ -780,6 +780,8 @@ public class DialogueSystem : MonoBehaviour, IDialogueOverrideHandler
     private void endDialogue(int answer = 0, bool soundOnClose = true)
     {
         speaker = null;
+        TaskManager.Instance?.SetSpeakerID(null);
+        SetSpeakerID(null);
         if (window)
         {
             window.playSoundOnClose = soundOnClose;

--- a/Assets/Scripts/Functional Definitions/Interaction Definitions/SectorManager.cs
+++ b/Assets/Scripts/Functional Definitions/Interaction Definitions/SectorManager.cs
@@ -239,7 +239,7 @@ public class SectorManager : MonoBehaviour
             dangerZoneTimer = 0;
         }
 
-        if (!DialogueSystem.isInCutscene)
+        if (!DialogueSystem.isInCutscene && TaskManager.GetSpeaker() == null)
         {
             bgSpawnTimer += Time.deltaTime;
 


### PR DESCRIPTION
The TaskManager and DialogueSystem don't really have a reference to the node which caused the dialogue, so I'm using the TaskManager.GetSpeaker(), this works but might not be the best solution.