### PR TITLE
Weapon Target Fix

### DIFF
--- a/Assets/Scripts/Functional Definitions/Abilities/Bomb.cs
+++ b/Assets/Scripts/Functional Definitions/Abilities/Bomb.cs
@@ -69,7 +69,7 @@ public class Bomb : WeaponAbility
         script.owner = GetComponentInParent<Entity>();
         script.SetDamage(GetDamage());
         script.SetCategory(type == WeaponDiversityType.Torpedo ? Entity.EntityCategory.All : category);
-        script.SetTerrain(type == WeaponDiversityType.Torpedo ? Entity.TerrainType.Ground : script.owner.Terrain);
+        script.SetTerrain(type == WeaponDiversityType.Torpedo ? Entity.TerrainType.Ground : terrain);
         script.bombColor = part && part.info.shiny ? FactionManager.GetFactionShinyColor(Core.faction) : new Color(0.8F, 1F, 1F, 0.9F);
         script.faction = Core.faction;
 

--- a/Assets/Scripts/Functional Definitions/Abilities/Bullet.cs
+++ b/Assets/Scripts/Functional Definitions/Abilities/Bullet.cs
@@ -96,7 +96,7 @@ public class Bullet : WeaponAbility
         script.owner = GetComponentInParent<Entity>();
         script.SetDamage(GetDamage());
         script.SetCategory(type == WeaponDiversityType.Torpedo ? Entity.EntityCategory.All : category);
-        script.SetTerrain(type == WeaponDiversityType.Torpedo ? Entity.TerrainType.Ground : script.owner.Terrain);
+        script.SetTerrain(type == WeaponDiversityType.Torpedo ? Entity.TerrainType.Ground : terrain);
         script.SetShooterFaction(Core.faction);
         script.SetPierceFactor(pierceFactor);
         script.particleColor = part && part.info.shiny ? FactionManager.GetFactionShinyColor(Core.faction) : new Color(0.8F, 1F, 1F, 0.9F);

--- a/Assets/Scripts/Functional Definitions/Abilities/Missile.cs
+++ b/Assets/Scripts/Functional Definitions/Abilities/Missile.cs
@@ -41,7 +41,7 @@ public class Missile : WeaponAbility
         script.owner = GetComponentInParent<Entity>();
         script.SetTarget(targetingSystem.GetTarget());
         script.SetCategory(type == WeaponDiversityType.Torpedo ? Entity.EntityCategory.All : category);
-        script.SetTerrain(type == WeaponDiversityType.Torpedo ? Entity.TerrainType.Ground : script.owner.Terrain);
+        script.SetTerrain(type == WeaponDiversityType.Torpedo ? Entity.TerrainType.Ground : terrain);
         script.faction = Core.faction;
         script.SetDamage(GetDamage());
         script.StartSurvivalTimer(3);


### PR DESCRIPTION
fixes Bullet, Missile, Bomb, and all derivatives using owning entity's terrain as projectile's target terrain.