### PR TITLE
update battleAI

### DIFF
--- a/Assets/Scripts/Game Object Definitions/Entity Definitions/Tank.cs
+++ b/Assets/Scripts/Game Object Definitions/Entity Definitions/Tank.cs
@@ -160,8 +160,8 @@ public class Tank : GroundCraft, IOwnable
 
         // Find a path to the closest one
         if (targets.Count == 0) return;
-        Vector2[] newPath = LandPlatformGenerator.pathfind(transform.position, targets.ToArray(), Weapons[0].GetRange());
-        if(newPath == null){newPath = LandPlatformGenerator.pathfind(transform.position, flags.ToArray(), Weapons[0].GetRange());}
+        Vector2[] newPath = LandPlatformGenerator.pathfind(transform.position, targets.ToArray(), null, Weapons[0].GetRange());
+        if(newPath == null){newPath = LandPlatformGenerator.pathfind(transform.position, null, flags.ToArray(), Weapons[0].GetRange());}
         if (!HasPath)
         {
             path = newPath;

--- a/Assets/Scripts/Game Object Definitions/Entity Definitions/Tank.cs
+++ b/Assets/Scripts/Game Object Definitions/Entity Definitions/Tank.cs
@@ -150,11 +150,18 @@ public class Tank : GroundCraft, IOwnable
                 i--;
             }
         }
+        
+        List<Vector2> flags = new List<Vector2>();
+        foreach(Flag flag in AIData.flags){
+            if(flag.name == $"tankpickup{faction}"){
+                flags.Add(flag.transform.position);
+            }
+        }
 
         // Find a path to the closest one
         if (targets.Count == 0) return;
         Vector2[] newPath = LandPlatformGenerator.pathfind(transform.position, targets.ToArray(), Weapons[0].GetRange());
-
+        if(newPath == null){newPath = LandPlatformGenerator.pathfind(transform.position, flags.ToArray(), Weapons[0].GetRange());}
         if (!HasPath)
         {
             path = newPath;

--- a/Assets/Scripts/SFX Scripts/LandPlatformGenerator.cs
+++ b/Assets/Scripts/SFX Scripts/LandPlatformGenerator.cs
@@ -517,7 +517,7 @@ public class LandPlatformGenerator : MonoBehaviour
         public Node parent;
     }
 
-    public static Vector2[] pathfind(Vector2 startPos, Entity[] targets, float maxDistance = 0f)
+    public static Vector2[] pathfind(Vector2 startPos, Entity[] targets, Vector2[] positions, float maxDistance = 0f)
     {
         float sqrDist = maxDistance * maxDistance;
 
@@ -527,188 +527,24 @@ public class LandPlatformGenerator : MonoBehaviour
 
         // Get end tiles
         List<Vector2Int> endTiles = new List<Vector2Int>();
-        for (int i = 0; i < targets.Length; i++)
-        {
-            var t = plat.GetClosestTile(targets[i]);
-            if ((TileToWorldPos(t.pos) - (Vector2)targets[i].transform.position).sqrMagnitude < sqrDist)
+        if(targets != null){
+            for (int i = 0; i < targets.Length; i++)
             {
-                endTiles.Add(t.pos);
-            }
-        }
-
-        if (endTiles.Count == 0)
-        {
-            return null;
-        }
-
-        if (endTiles.Contains(startTilePos))
-        {
-            return new Vector2[] { TileToWorldPos(startTilePos) };
-        }
-
-        // Initialize node lists
-        // TODO: Queue instead of List?
-        List<Node> openList = new List<Node>
-        {
-            new Node
-            {
-                pos = startTilePos,
-                directions = instance.GetDirections(startTilePos),
-                parent = null
-            }
-        };
-        List<Vector2Int> closedList = new List<Vector2Int>();
-
-        // Initialize direction vectors
-        Vector2Int[] unitVectors = new Vector2Int[]
-        {
-            new Vector2Int(1, 0),
-            new Vector2Int(0, -1),
-            new Vector2Int(-1, 0),
-            new Vector2Int(0, 1)
-        };
-
-        // Start flood fill
-        while (openList.Count > 0)
-        {
-            Node current = openList[0];
-
-            // Check for end tiles
-            for (int i = 0; i < endTiles.Count; i++)
-            {
-                if (current.pos == endTiles[i])
+                var t = plat.GetClosestTile(targets[i]);
+                if ((TileToWorldPos(t.pos) - (Vector2)targets[i].transform.position).sqrMagnitude < sqrDist)
                 {
-                    // Path found!
-                    List<Vector2> path = new List<Vector2>();
-                    while (current.parent != null)
-                    {
-                        path.Add(TileToWorldPos(current.pos));
-                        current = current.parent;
-
-                        if (path.Count > 10000)
-                        {
-                            Debug.LogError("Infinite loop at path construction.");
-                            return null;
-                        }
-                    }
-
-                    // Add parentless start position
-                    if ((current.directions == 3 ||
-                        current.directions == 6 ||
-                        current.directions == 9 ||
-                        current.directions == 12) &&
-                        path.Count > 1)
-                    {
-                        Vector2 last = (TileToWorldPos(current.pos));
-                        Vector2 smoothed = (path[path.Count - 1] * 0.35f) + (last * 0.65f);
-                        path.Add(smoothed);
-                    }
-                    else
-                    {
-                        path.Add(TileToWorldPos(current.pos));
-                    }
-
-                    if (path.Count > 1)
-                    {
-                        if (instance.isInLoS(startPos, path[path.Count - 2]))
-                        {
-                            path.RemoveAt(path.Count - 1);
-                        }
-                    }
-
-
-                    List<Vector2> smooth = new List<Vector2> { path[0] };
-
-                    // Path smoothing
-                    if (path.Count > 2)
-                    {
-                        for (int j = 1; j < path.Count - 1; j++)
-                        {
-                            if (path[j - 1].x != path[j + 1].x && path[j - 1].y != path[j + 1].y)
-                            {
-                                Vector2 prev = (path[j - 1] * 0.35f) + (path[j] * 0.65f);
-                                Vector2 next = (path[j + 1] * 0.35f) + (path[j] * 0.65f);
-
-                                smooth.Add(prev);
-                                smooth.Add(next);
-                            }
-                            else
-                            {
-                                smooth.Add(path[j]);
-                            }
-                        }
-                    }
-                    if (path.Count > 1)
-                    {
-                        smooth.Add(path[path.Count - 1]);
-                    }
-
-                    // Path from end to start. Tanks start fron the last node index.
-                    return smooth.ToArray();
+                    endTiles.Add(t.pos);
                 }
             }
-
-            // Add new nodes
-            for (int i = 0; i < 4; i++)
-            {
-                if ((current.directions & (1 << i)) == (1 << i))
-                {
-                    Vector2Int nextPos = current.pos + unitVectors[i];
-                    short dirs = instance.GetDirections(nextPos);
-                    if (dirs == -1)
-                    {
-                        // Road ends!
-                        continue;
-                    }
-                    if (!closedList.Contains(nextPos))
-                    {
-                        bool found = false;
-                        for (int j = 0; j < openList.Count; j++)
-                        {
-                            if (openList[j].pos == nextPos)
-                            {
-                                found = true;
-                                break;
-                            }
-                        }
-                        if (!found)
-                        {
-                            openList.Add(
-                                new Node
-                                {
-                                    pos = nextPos,
-                                    directions = dirs,
-                                    parent = current
-                                });
-                        }
-                    }
-                }
-            }
-
-            openList.RemoveAt(0);
         }
-
-        // It's possible for there to be no path to any target, so it's okay to return nothing
-        Debug.Log($"No viable path found to any of the [{endTiles.Count}] destinations.");
-        return null;
-    }
-
-    public static Vector2[] pathfind(Vector2 startPos, Vector2[] positions, float maxDistance = 0f)
-    {
-        float sqrDist = maxDistance * maxDistance;
-
-        // Get correct platform and the starting tile
-        var plat = Instance.GetPlatformInPosition(startPos);
-        Vector2Int startTilePos = WorldToTilePos(startPos);
-
-        // Get end tiles
-        List<Vector2Int> endTiles = new List<Vector2Int>();
-        for (int i = 0; i < positions.Length; i++)
-        {
-            var t = instance.GetNearestTile(plat, positions[i]).Value;
-            if ((TileToWorldPos(t.pos) - positions[i]).sqrMagnitude < sqrDist)
+        else{
+            for (int i = 0; i < positions.Length; i++)
             {
-                endTiles.Add(t.pos);
+                var t = instance.GetNearestTile(plat, positions[i]).Value;
+                if ((TileToWorldPos(t.pos) - positions[i]).sqrMagnitude < sqrDist)
+                {
+                    endTiles.Add(t.pos);
+                }
             }
         }
 


### PR DESCRIPTION
tested in a few custom battlezones as well as the 3 haven 5 (4?) battlezones, seems to work fine so far
-allows the AI to accurately drop their tanks on the target flag rather than occasionally missing
-the AI will drop tanks as part of their attack AI rather than their ground reinforcement AI (since the latter triggers based on the need for tanks' existence)
-AI no longer considers ground stations as bunkers for purchasing tanks (this caused them to sometimes get stuck trying to purchase tanks from their base) 
-tanks will attempt to drive to the nearest pickup point if they have no valid target to drive to and shoot (note: I duplicated the pathfinding function to do this because I thought it would be better than trying to rewrite all the pathfinding code to use positions instead of entities)
-AI will go to pickup points as part of their attack AI as long as its not out of the way and there's a valid dropoff point (dropoff points are not valid if there's already too many allied units nearby)
TODO:
-AI does not drop tanks if a more important task is found 
-AI will not pick up previously-dropped tanks if theyre not near a flag (i.e. airborne)
-pickup and dropoff flags can form an infinite loop if there is a path between them and they are too close together 