### PR TITLE
Fix ShipBuilder part info display issue

### DIFF
--- a/Assets/Prefabs/HUD Prefabs/Ship Builder.prefab
+++ b/Assets/Prefabs/HUD Prefabs/Ship Builder.prefab
@@ -7789,9 +7789,6 @@ MonoBehaviour:
   canvas: {fileID: 7943546138175678975}
   grid: {fileID: 9201380905970821497}
   currentPart: {fileID: 0}
-  ZoomMax: 2.5
-  ZoomMin: 0.5
-  zoomStep: 0.1
   builder: {fileID: 0}
   searchField: {fileID: 0}
   jsonField: {fileID: 8517533089547041540}

--- a/Assets/Prefabs/HUD Prefabs/Ship Builder.prefab
+++ b/Assets/Prefabs/HUD Prefabs/Ship Builder.prefab
@@ -6595,10 +6595,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546137812160534}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 83, y: -31.199999}
-  m_SizeDelta: {x: 160, y: 12}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7943546137211319257
 CanvasRenderer:
@@ -6674,10 +6674,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546139026039084}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 83, y: -6}
-  m_SizeDelta: {x: 160, y: 12}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7943546137265671159
 CanvasRenderer:
@@ -7062,7 +7062,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 7943546137576888660}
   m_HandleRect: {fileID: 7943546137576888659}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -7789,6 +7789,9 @@ MonoBehaviour:
   canvas: {fileID: 7943546138175678975}
   grid: {fileID: 9201380905970821497}
   currentPart: {fileID: 0}
+  ZoomMax: 2.5
+  ZoomMin: 0.5
+  zoomStep: 0.1
   builder: {fileID: 0}
   searchField: {fileID: 0}
   jsonField: {fileID: 8517533089547041540}
@@ -7923,7 +7926,7 @@ RectTransform:
   m_Father: {fileID: 7943546138920589801}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -8074,9 +8077,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546137812160534}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 53, y: -37.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7943546137617303880
@@ -8549,9 +8552,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546139026039084}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 53, y: -12.3}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7943546137779723012
@@ -8689,10 +8692,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546139026039084}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 83, y: -18.6}
-  m_SizeDelta: {x: 160, y: 12}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7943546137797079648
 CanvasRenderer:
@@ -8777,7 +8780,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 40.5}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &7943546137812162536
 MonoBehaviour:
@@ -9416,9 +9419,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546139026039084}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 53, y: -24.9}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7943546137936292160
@@ -9724,9 +9727,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546137812160534}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 53, y: -12.3}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7943546138022989768
@@ -10153,7 +10156,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &7943546139253344280
 RectTransform:
   m_ObjectHideFlags: 0
@@ -11030,7 +11033,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 7943546139237427245}
   m_HandleRect: {fileID: 7943546139237427244}
   m_Direction: 2
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -11067,9 +11070,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546137812160534}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 53, y: -24.9}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7943546138413674811
@@ -11248,10 +11251,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546139026039084}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 83, y: -31.199999}
-  m_SizeDelta: {x: 160, y: 12}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7943546138452271057
 CanvasRenderer:
@@ -11834,7 +11837,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7abb7e83f853e23478302b5f947f78ad, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  builderInterfaceContainer: {fileID: 8776915232209613949}
   input: {fileID: 7943546138715558148}
 --- !u!1 &7943546138796589142
 GameObject:
@@ -12134,9 +12136,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546139026039084}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 53, y: -37.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7943546138892903471
@@ -12611,7 +12613,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 40.5}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &7943546139026039086
 MonoBehaviour:
@@ -12788,10 +12790,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546137812160534}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 83, y: -6}
-  m_SizeDelta: {x: 160, y: 12}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7943546139116738773
 CanvasRenderer:
@@ -12867,10 +12869,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546137812160534}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 83, y: -18.6}
-  m_SizeDelta: {x: 160, y: 12}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7943546139123195021
 CanvasRenderer:
@@ -13247,7 +13249,7 @@ RectTransform:
   m_Father: {fileID: 7943546138884624921}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -14660,6 +14662,7 @@ MonoBehaviour:
   editorModeAddPartSection: {fileID: 1410628452}
   jsonButtonHolder: {fileID: 8620493361618288234}
   searchBar: {fileID: 7943546138715558151}
+  partDisplay: {fileID: 7943546138796589098}
   partSelectContainer: {fileID: 8464175627931194394}
   partSelectTransforms:
   - {fileID: 4484554199426117513}

--- a/Assets/Prefabs/HUD Prefabs/Ship Builder.prefab
+++ b/Assets/Prefabs/HUD Prefabs/Ship Builder.prefab
@@ -7062,8 +7062,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 7943546137576888660}
   m_HandleRect: {fileID: 7943546137576888659}
   m_Direction: 2
-  m_Value: 0
-  m_Size: 1
+  m_Value: 1
+  m_Size: 0.34652877
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -7922,8 +7922,8 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546138920589801}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 0.65347123}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -8777,7 +8777,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 40.5}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &7943546137812162536
 MonoBehaviour:
@@ -10153,7 +10153,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &7943546139253344280
 RectTransform:
   m_ObjectHideFlags: 0
@@ -12606,8 +12606,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.000061035156}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: -0.00012207031}
+  m_SizeDelta: {x: 0, y: 40.5}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &7943546139026039086
 MonoBehaviour:
@@ -13243,7 +13243,7 @@ RectTransform:
   m_Father: {fileID: 7943546138884624921}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Prefabs/HUD Prefabs/Ship Builder.prefab
+++ b/Assets/Prefabs/HUD Prefabs/Ship Builder.prefab
@@ -6595,10 +6595,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546137812160534}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 160, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 83, y: -31.199999}
+  m_SizeDelta: {x: 160, y: 12}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7943546137211319257
 CanvasRenderer:
@@ -6674,10 +6674,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546139026039084}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 160, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 83, y: -6}
+  m_SizeDelta: {x: 160, y: 12}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7943546137265671159
 CanvasRenderer:
@@ -8074,9 +8074,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546137812160534}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 53, y: -37.5}
   m_SizeDelta: {x: 100, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7943546137617303880
@@ -8549,9 +8549,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546139026039084}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 53, y: -12.3}
   m_SizeDelta: {x: 100, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7943546137779723012
@@ -8689,10 +8689,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546139026039084}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 160, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 83, y: -18.6}
+  m_SizeDelta: {x: 160, y: 12}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7943546137797079648
 CanvasRenderer:
@@ -9416,9 +9416,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546139026039084}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 53, y: -24.9}
   m_SizeDelta: {x: 100, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7943546137936292160
@@ -9724,9 +9724,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546137812160534}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 53, y: -12.3}
   m_SizeDelta: {x: 100, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7943546138022989768
@@ -11067,9 +11067,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546137812160534}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 53, y: -24.9}
   m_SizeDelta: {x: 100, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7943546138413674811
@@ -11248,10 +11248,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546139026039084}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 160, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 83, y: -31.199999}
+  m_SizeDelta: {x: 160, y: 12}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7943546138452271057
 CanvasRenderer:
@@ -11908,9 +11908,6 @@ MonoBehaviour:
   buttonScript: {fileID: 8046717000822842502}
   abilityBox: {fileID: 8046312677669257428}
   emptyInfoMarker: {fileID: 7943546137915982064}
-  builder: {fileID: 0}
-  cursorScript: {fileID: 7943546137540392347}
-  builderBG: {fileID: 7943546137579198215}
 --- !u!1 &7943546138867225263
 GameObject:
   m_ObjectHideFlags: 0
@@ -12133,9 +12130,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546139026039084}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 53, y: -37.5}
   m_SizeDelta: {x: 100, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7943546138892903471
@@ -12609,7 +12606,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: -0.000061035156}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &7943546139026039086
@@ -12787,10 +12784,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546137812160534}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 160, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 83, y: -6}
+  m_SizeDelta: {x: 160, y: 12}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7943546139116738773
 CanvasRenderer:
@@ -12866,10 +12863,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7943546137812160534}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 160, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 83, y: -18.6}
+  m_SizeDelta: {x: 160, y: 12}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7943546139123195021
 CanvasRenderer:
@@ -14660,6 +14657,7 @@ MonoBehaviour:
   jsonButtonHolder: {fileID: 8620493361618288234}
   searchBar: {fileID: 7943546138715558151}
   partDisplay: {fileID: 7943546138796589098}
+  partsListScrollViewRectTransform: {fileID: 7943546139257753907}
   partSelectContainer: {fileID: 8464175627931194394}
   partSelectTransforms:
   - {fileID: 4484554199426117513}

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilder.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilder.cs
@@ -64,6 +64,8 @@ public class ShipBuilder : GUIWindowScripts
     private ShpBuilderSearch searchBar;
     [SerializeField]
     private ShipBuilderPartDisplay partDisplay;
+    [SerializeField]
+    private RectTransform partsListScrollViewRectTransform;
 
     public void RemoveKeyFromPartDict(EntityBlueprint.PartInfo info)
     {
@@ -1686,12 +1688,15 @@ public class ShipBuilder : GUIWindowScripts
 
     public EntityBlueprint.PartInfo? GetInfoForHoveredPart()
     {
-        foreach (ShipBuilderInventoryScript inv in partDict.Values)
+        if (RectTransformUtility.RectangleContainsScreenPoint(partsListScrollViewRectTransform, Input.mousePosition))
         {
-            if (RectTransformUtility.RectangleContainsScreenPoint(inv.GetComponent<RectTransform>(), Input.mousePosition)
-                && inv.gameObject.activeSelf)
+            foreach (ShipBuilderInventoryScript inv in partDict.Values)
             {
-                return inv.part;
+                if (RectTransformUtility.RectangleContainsScreenPoint(inv.GetComponent<RectTransform>(), Input.mousePosition)
+                    && inv.gameObject.activeSelf)
+                {
+                    return inv.part;
+                }
             }
         }
 

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilder.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilder.cs
@@ -1606,8 +1606,7 @@ public class ShipBuilder : GUIWindowScripts
     {
         base.Update();
 
-        if (Time.frameCount % 2 == 0) // UpdatePartInfo() can be pretty expensive.
-            UpdatePartInfo();
+        UpdatePartInfo();
         
         if (!editorMode)
         {

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilder.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilder.cs
@@ -62,6 +62,8 @@ public class ShipBuilder : GUIWindowScripts
     private GameObject jsonButtonHolder;
     [SerializeField]
     private ShpBuilderSearch searchBar;
+    [SerializeField]
+    private ShipBuilderPartDisplay partDisplay;
 
     public void RemoveKeyFromPartDict(EntityBlueprint.PartInfo info)
     {
@@ -821,8 +823,6 @@ public class ShipBuilder : GUIWindowScripts
         Activate();
         cursorScript.gameObject.SetActive(false);
         cursorScript.SetBuilder(this, droneWorkshopPhaseHider);
-
-        GetComponentInChildren<ShipBuilderPartDisplay>().Initialize(this);
 
         // set up actual stats
         this.mode = mode;
@@ -1603,6 +1603,10 @@ public class ShipBuilder : GUIWindowScripts
     protected override void Update()
     {
         base.Update();
+
+        if (Time.frameCount % 2 == 0) // UpdatePartInfo() can be pretty expensive.
+            UpdatePartInfo();
+        
         if (!editorMode)
         {
             if ((player.transform.position - yardPosition).sqrMagnitude > 200 || player.GetIsDead())
@@ -1680,7 +1684,7 @@ public class ShipBuilder : GUIWindowScripts
         public List<EntityBlueprint.PartInfo> parts;
     }
 
-    public EntityBlueprint.PartInfo? GetButtonPartCursorIsOn()
+    public EntityBlueprint.PartInfo? GetInfoForHoveredPart()
     {
         foreach (ShipBuilderInventoryScript inv in partDict.Values)
         {
@@ -1700,7 +1704,7 @@ public class ShipBuilder : GUIWindowScripts
             }
         }
 
-        return null;
+        return cursorScript.GetInfoForHoveredPartInGrid();
     }
 
     public void ChangeDisplayFactors()
@@ -1819,6 +1823,20 @@ public class ShipBuilder : GUIWindowScripts
         ChangeDisplayFactors();
     }
 
+    private void UpdatePartInfo()
+    {
+        EntityBlueprint.PartInfo? part = GetInfoForHoveredPart();
+
+        if (part != null)
+        {
+            partDisplay.DisplayPartInfo((EntityBlueprint.PartInfo)part);
+        }
+        else
+        {
+            partDisplay.SetInactive();
+        }
+    }
+
     public override bool GetActive()
     {
         return gameObject.activeSelf;
@@ -1833,31 +1851,5 @@ public class ShipBuilder : GUIWindowScripts
         }
 
         base.OnPointerDown(eventData);
-    }
-
-    public EntityBlueprint.PartInfo? RequestInventoryMouseOverInfo()
-    {
-        foreach (var part in partDict)
-        {
-            if (RectTransformUtility.RectangleContainsScreenPoint(part.Value.GetComponent<RectTransform>(), Input.mousePosition) &&
-                part.Value.gameObject.activeSelf)
-            {
-                return part.Key;
-            }
-        }
-
-        if (traderPartDict != null)
-        {
-            foreach (var part in traderPartDict)
-            {
-                if (RectTransformUtility.RectangleContainsScreenPoint(part.Value.GetComponent<RectTransform>(), Input.mousePosition) &&
-                    part.Value.gameObject.activeSelf)
-                {
-                    return part.Key;
-                }
-            }
-        }
-
-        return null;
     }
 }

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
@@ -5,6 +5,10 @@ using UnityEngine.UI;
 
 public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
 {
+    private const float ZoomMax = 2.5f;
+    private const float ZoomMin = 0.5f;
+    private const float ZoomStep = 0.1f;
+    
     public List<ShipBuilderPart> parts = new List<ShipBuilderPart>();
     public Canvas canvas;
     public RectTransform grid;
@@ -36,18 +40,10 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
 
     public bool IsMouseOnGrid => RectTransformUtility.RectangleContainsScreenPoint(grid2mask, Input.mousePosition);
 
-    private float zoomMax = 2.5f;
-    private float zoomMin = 0.5f;
-    private float zoomStep = 0.1f;
-    private float zoom;
     private float Zoom
     {
-        get { return zoom; }
-        set
-        {
-            zoom = value;
-            grid.localScale = new Vector3(1, 1, 0) * value;
-        }
+        get => grid.localScale.x;
+        set => grid.localScale = new Vector3(1, 1, 0) * value;
     }
 
     public void SetMode(BuilderMode mode)
@@ -160,7 +156,7 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
                     ? ShipBuilder.TransferMode.Return
                     : ShipBuilder.TransferMode.Buy);
             }
-            else if (!isMouseOnGrid)
+            else if (!IsMouseOnGrid)
             {
                 dispatch = true;
                 mode = ShipBuilder.TransferMode.Return;
@@ -676,7 +672,7 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
 
         float oldZoom = Zoom;
 
-        Zoom = Mathf.Clamp(Zoom + Input.mouseScrollDelta.y * zoomStep * Zoom, zoomMin, zoomMax);
+        Zoom = Mathf.Clamp(Zoom + Input.mouseScrollDelta.y * ZoomStep * Zoom, ZoomMin, ZoomMax);
 
         // Move grid to keep mouse at the same position after zooming
         Vector3 mousePositionRelativeToGridCenter = (Input.mousePosition - grid.position) / oldZoom;

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
@@ -34,7 +34,7 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
     bool clickedOnce;
     float timer;
 
-    public static bool isMouseOnGrid = false;
+    public bool IsMouseOnGrid => RectTransformUtility.RectangleContainsScreenPoint(grid2mask, Input.mousePosition);
 
     private float zoomMax = 2.5f;
     private float zoomMin = 0.5f;
@@ -274,19 +274,17 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
         }
     }
 
-    public EntityBlueprint.PartInfo? GetPartCursorIsOn()
+    public EntityBlueprint.PartInfo? GetInfoForHoveredPartInGrid()
     {
-        foreach (ShipBuilderPart part in parts)
+        if (IsMouseOnGrid)
         {
-            if (RectTransformUtility.RectangleContainsScreenPoint(part.rectTransform, Input.mousePosition))
+            foreach (ShipBuilderPart part in parts)
             {
-                return part.info;
+                if (RectTransformUtility.RectangleContainsScreenPoint(part.rectTransform, Input.mousePosition))
+                {
+                    return part.info;
+                }
             }
-        }
-
-        if (builder is ShipBuilder shipBuilder)
-        {
-            return shipBuilder.RequestInventoryMouseOverInfo();
         }
 
         return null;
@@ -417,8 +415,6 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
     void Update()
     {
         UpdateCompact();
-
-        isMouseOnGrid = RectTransformUtility.RectangleContainsScreenPoint(grid2mask, Input.mousePosition);
 
         if (clickedOnce)
         {
@@ -572,11 +568,6 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
     // symmetry mode enables checks based on symmetryPart - same part ID, ability ID, different mirrored
     public ShipBuilderPart FindPart(Vector2 vector, ShipBuilderPart symmetryPart, bool useBounds = false)
     {
-        if (!isMouseOnGrid)
-        {
-            return null;
-        }
-
         for (int i = parts.Count - 1; i >= 0; i--)
         {
             var origPos = transform.position;
@@ -678,7 +669,7 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
 
     private void HandleZooming()
     {
-        if (Input.mouseScrollDelta.y == 0 || !isMouseOnGrid || !PointerOverDetector.isPointerOver)
+        if (Input.mouseScrollDelta.y == 0 || !IsMouseOnGrid || !PointerOverDetector.isPointerOver)
         {
             return;
         }

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderPart.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderPart.cs
@@ -94,35 +94,32 @@ public class ShipBuilderPart : DisplayPart, IPointerEnterHandler, IPointerExitHa
         {
             image.color = (info.isInChain && info.validPos ? mainColor : mainColor - new Color(0, 0, 0, 0.5F));
 
-            if (ShipBuilderCursorScript.isMouseOnGrid)
+            switch (cursorScript.symmetryMode)
             {
-                switch (cursorScript.symmetryMode)
-                {
-                    case ShipBuilderCursorScript.SymmetryMode.X:
-                    case ShipBuilderCursorScript.SymmetryMode.Y:
-                        var symVec = cursorScript.GetSymmetrizedVector(rectTransform.anchoredPosition, cursorScript.symmetryMode);
-                        var symmetryPart = cursorScript.FindPart(symVec, this);
-                        var onAxis = false;
-                        if (cursorScript.symmetryMode == ShipBuilderCursorScript.SymmetryMode.X)
-                        {
-                            onAxis = Mathf.Abs(rectTransform.anchoredPosition.y) < ShipBuilderCursorScript.stepSize;
-                        }
+                case ShipBuilderCursorScript.SymmetryMode.X:
+                case ShipBuilderCursorScript.SymmetryMode.Y:
+                    var symVec = cursorScript.GetSymmetrizedVector(rectTransform.anchoredPosition, cursorScript.symmetryMode);
+                    var symmetryPart = cursorScript.FindPart(symVec, this);
+                    var onAxis = false;
+                    if (cursorScript.symmetryMode == ShipBuilderCursorScript.SymmetryMode.X)
+                    {
+                        onAxis = Mathf.Abs(rectTransform.anchoredPosition.y) < ShipBuilderCursorScript.stepSize;
+                    }
 
-                        if (cursorScript.symmetryMode == ShipBuilderCursorScript.SymmetryMode.X)
-                        {
-                            onAxis = Mathf.Abs(rectTransform.anchoredPosition.x) < ShipBuilderCursorScript.stepSize;
-                        }
+                    if (cursorScript.symmetryMode == ShipBuilderCursorScript.SymmetryMode.X)
+                    {
+                        onAxis = Mathf.Abs(rectTransform.anchoredPosition.x) < ShipBuilderCursorScript.stepSize;
+                    }
 
-                        if ((!symmetryPart || (symmetryPart.rectTransform.anchoredPosition - symVec).sqrMagnitude >
-                            ShipBuilderCursorScript.stepSize) && !onAxis)
-                        {
-                            image.color = FactionManager.GetFactionColor(1);
-                        }
+                    if ((!symmetryPart || (symmetryPart.rectTransform.anchoredPosition - symVec).sqrMagnitude >
+                        ShipBuilderCursorScript.stepSize) && !onAxis)
+                    {
+                        image.color = FactionManager.GetFactionColor(1);
+                    }
 
-                        break;
-                    default:
-                        break;
-                }
+                    break;
+                default:
+                    break;
             }
 
             image.material = null;

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderPartDisplay.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderPartDisplay.cs
@@ -1,47 +1,12 @@
-﻿using UnityEngine;
-using UnityEngine.UI;
+﻿using UnityEngine.UI;
 
 public class ShipBuilderPartDisplay : PartDisplayBase
 {
-    public ShipBuilder builder;
-    public ShipBuilderCursorScript cursorScript;
-    public RectTransform builderBG;
-    bool initialized = false;
-
-    public void Initialize(ShipBuilder inter)
+    public void Awake()
     {
-        builder = inter;
-        initialized = true;
         image.type = Image.Type.Sliced;
         abilityImage.type = Image.Type.Sliced;
         abilityTier.type = Image.Type.Sliced;
         SetInactive();
-    }
-
-
-    // Update is called once per frame
-    void Update()
-    {
-        // Gets the part to diplsay using the method GetButtonPartCursorIsOn() in IBuilderInterface
-
-        if (initialized)
-        {
-            EntityBlueprint.PartInfo? part = null;
-            if (cursorScript.GetPartCursorIsOn() != null)
-            {
-                part = cursorScript.GetPartCursorIsOn();
-            }
-
-            if (part != null)
-            {
-                EntityBlueprint.PartInfo info = (EntityBlueprint.PartInfo)part;
-                DisplayPartInfo(info);
-                emptyInfoMarker.SetActive(false);
-            }
-            else
-            {
-                SetInactive();
-            }
-        }
     }
 }


### PR DESCRIPTION
This time properly checking if the cursor is on top of the ShipBuilder's grid mask or parts inventory's scroll area before checking if the mouse is over a part.

Since it still checks the mouse position against every list item and every part in the grid when the mouse isn't over any part I made it only check every second frame.

TL;DR: Can only view part info in the ShipBuilder when actually hovering a part now.