### PR TITLE
Party Member Bugfix

### DIFF
--- a/Assets/Scripts/Functional Definitions/Saving Scripts/PlayerSave.cs
+++ b/Assets/Scripts/Functional Definitions/Saving Scripts/PlayerSave.cs
@@ -63,7 +63,7 @@ public class PlayerSave
     // As well as for side missions to not change the episode number.
     public int episode;
 
-    public bool partyLock;
+    //public bool partyLock;
     // The three lists contain IDs of unlocked, locked, and current party members
     public List<string> unlockedPartyIDs;
     public List<string> disabledPartyIDs;

--- a/Assets/Scripts/Functional Definitions/Saving Scripts/PlayerSave.cs
+++ b/Assets/Scripts/Functional Definitions/Saving Scripts/PlayerSave.cs
@@ -63,10 +63,11 @@ public class PlayerSave
     // As well as for side missions to not change the episode number.
     public int episode;
 
-    // Contains IDs of unlocked party members (there will be a node that unlocks members adding IDs into this list)
+    public bool partyLock;
+    // The three lists contain IDs of unlocked, locked, and current party members
     public List<string> unlockedPartyIDs;
-    // Disabled party members. Saved so that EP3 persistent party locking does not need constant checkpoints
     public List<string> disabledPartyIDs;
+    public List<string> currentPartyMembers;
     public AbilityHotkeyStruct abilityHotkeys;
     public List<string> locationBasedShardsFound;
     public int lastDimension;

--- a/Assets/Scripts/Functional Definitions/Saving Scripts/SaveHandler.cs
+++ b/Assets/Scripts/Functional Definitions/Saving Scripts/SaveHandler.cs
@@ -92,6 +92,18 @@ public class SaveHandler : MonoBehaviour
             }
             if (MasterNetworkAdapter.mode == MasterNetworkAdapter.NetworkMode.Off)
                 StartCoroutine(Autobackup());
+
+            /*if (save.currentPartyMembers.Count != 0) // Currently broken, I do not know why this is null
+            {
+                foreach (var charID in save.currentPartyMembers)
+                {
+                    PartyManager.instance.AssignBackend(charID);
+                }
+                save.currentPartyMembers.Clear();
+            }*/
+
+            if (save.partyLock)
+                PartyManager.instance.SetOverrideLock(save.partyLock);
         }
         else
         {
@@ -195,6 +207,13 @@ public class SaveHandler : MonoBehaviour
         playerSave.taskVariableNames = keys;
         playerSave.taskVariableValues = values;
         playerSave.reputation = player.reputation;
+
+        playerSave.currentPartyMembers.Clear();
+        foreach (var member in PartyManager.instance.partyMembers)
+        {
+            playerSave.currentPartyMembers.Add(member.ID);
+        }
+        playerSave.partyLock = PartyManager.instance.GetOverrideLock();
     }
 
     public void Save()

--- a/Assets/Scripts/Functional Definitions/Saving Scripts/SaveHandler.cs
+++ b/Assets/Scripts/Functional Definitions/Saving Scripts/SaveHandler.cs
@@ -102,8 +102,8 @@ public class SaveHandler : MonoBehaviour
                 save.currentPartyMembers.Clear();
             }*/
 
-            if (save.partyLock)
-                PartyManager.instance.SetOverrideLock(save.partyLock);
+            //if (save.partyLock)
+                //PartyManager.instance.SetOverrideLock(save.partyLock);
         }
         else
         {
@@ -213,7 +213,7 @@ public class SaveHandler : MonoBehaviour
         {
             playerSave.currentPartyMembers.Add(member.ID);
         }
-        playerSave.partyLock = PartyManager.instance.GetOverrideLock();
+        //playerSave.partyLock = PartyManager.instance.GetOverrideLock();
     }
 
     public void Save()

--- a/Assets/Scripts/Game Object Definitions/AI/PartyManager.cs
+++ b/Assets/Scripts/Game Object Definitions/AI/PartyManager.cs
@@ -28,6 +28,11 @@ public class PartyManager : MonoBehaviour
         overrideLock = val;
     }
 
+    public bool GetOverrideLock()
+    {
+        return overrideLock;
+    }
+
     public void OrderAttack()
     {
         PassiveDialogueSystem.Instance.ResetPassiveDialogueQueueTime();

--- a/Assets/Scripts/HUD Scripts/SaveMenuHandler.cs
+++ b/Assets/Scripts/HUD Scripts/SaveMenuHandler.cs
@@ -509,9 +509,11 @@ public class SaveMenuHandler : GUIWindowScripts
         save.currentPlayerBlueprint = JsonUtility.ToJson(blueprint);
         save.abilityCaps = CoreUpgraderScript.minAbilityCap;
         save.shards = 0;
+        //save.partyLock = false;
         save.version = currentVersion;
         save.resourcePath = resourcePath;
         save.abilityHotkeys = new AbilityHotkeyStruct();
+        //save.currentPartyMembers = new List<string>();
 
         var savesDir = System.IO.Path.Combine(Application.persistentDataPath, "Saves");
         Directory.CreateDirectory(savesDir);


### PR DESCRIPTION
This is mainly to fix an issue related to the party member system.
- Save files will remember if the party was locked from the lock party node or from the corescripts.
- Save files will remember the party members who were currently in your party.