### PR TITLE
Fix Core Upgrader AI

### DIFF
--- a/Assets/Scripts/Game Object Definitions/Entity Definitions/CoreUpgrader.cs
+++ b/Assets/Scripts/Game Object Definitions/Entity Definitions/CoreUpgrader.cs
@@ -5,4 +5,10 @@
         Category = EntityCategory.Station;
         base.Start();
     }
+
+    protected override void Update()
+    {
+        base.Update();
+        TickAbilitiesAsStation();
+    }
 }


### PR DESCRIPTION
Fixes an issue where core upgraders do not have ai. They should be able to use their weapons.

If you want to prove this is an issue, just go near an enemy core upgrader.