### PR TITLE
Part and Shard Collection Overhaul

### DIFF
--- a/Assets/Scripts/Functional Definitions/Interaction Definitions/SectorManager.cs
+++ b/Assets/Scripts/Functional Definitions/Interaction Definitions/SectorManager.cs
@@ -1650,7 +1650,8 @@ public class SectorManager : MonoBehaviour
         var remainingRocks = new List<Draggable>();
         foreach (var shard in AIData.rockFragments)
         {
-            if (shard && !shard.dragging)
+            if (shard && (shard.dragging || Vector3.SqrMagnitude(shard.transform.position - player.transform.position)
+                < objectDespawnDistance))
             {
                 Destroy(shard.gameObject);
             }

--- a/Assets/Scripts/Functional Definitions/Interaction Definitions/SectorManager.cs
+++ b/Assets/Scripts/Functional Definitions/Interaction Definitions/SectorManager.cs
@@ -1653,9 +1653,9 @@ public class SectorManager : MonoBehaviour
             if (shard && (shard.dragging || Vector3.SqrMagnitude(shard.transform.position - player.transform.position)
                 < objectDespawnDistance))
             {
-                Destroy(shard.gameObject);
+                remainingRocks.Add(shard);
             }
-            else remainingRocks.Add(shard);
+            else Destroy(shard.gameObject);
 
         }
         AIData.rockFragments = remainingRocks;

--- a/Assets/Scripts/Game Object Definitions/Entity Definitions/Yard.cs
+++ b/Assets/Scripts/Game Object Definitions/Entity Definitions/Yard.cs
@@ -40,7 +40,7 @@ public class Yard : AirConstruct, IShipBuilder
     public static readonly int YardProximitySquared = 75;
     private static float lastPartTakenTime = 0;
     private static int partsTakenCombo = 0, shardsTakenCombo = 0;
-    public static string entityID;
+    public static string collectingYardID;
 
     protected override void Update()
     {
@@ -208,7 +208,7 @@ public class Yard : AirConstruct, IShipBuilder
             Yard.lastPartTakenTime = Time.time;
             Yard.partsTakenCombo++;
         }
-        entityID = entity.ID;
+        collectingYardID = entity.ID;
         var shellPart = tractor.GetTractorTarget().GetComponent<ShellPart>();
         var info = shellPart.info;
         info = ShipBuilder.CullSpatialValues(info);
@@ -225,7 +225,7 @@ public class Yard : AirConstruct, IShipBuilder
 
     public static void TakeShard(Entity entity, TractorBeam tractor)
     {
-        entityID = entity.ID;
+        collectingYardID = entity.ID;
 
         var shard = tractor.GetTractorTarget().GetComponent<Shard>();
         var tiers = new int[] { 1, 5, 20 };
@@ -245,11 +245,11 @@ public class Yard : AirConstruct, IShipBuilder
         if (Yard.partsTakenCombo > 1)
         {
             string message = string.Format("Your {0} parts have been added into your inventory.", Yard.partsTakenCombo);
-            PassiveDialogueSystem.Instance.PushPassiveDialogue(entityID, message, 4, true);
+            PassiveDialogueSystem.Instance.PushPassiveDialogue(collectingYardID, message, 4, true);
         }
         else
         {
-            PassiveDialogueSystem.Instance.PushPassiveDialogue(entityID, "Your part has been added into your inventory.", 4, true);
+            PassiveDialogueSystem.Instance.PushPassiveDialogue(collectingYardID, "Your part has been added into your inventory.", 4, true);
         }
         Yard.partsTakenCombo = 0;
     }
@@ -259,11 +259,11 @@ public class Yard : AirConstruct, IShipBuilder
         if (Yard.shardsTakenCombo > 1)
         {
             string message = string.Format("Your {0} shards have been added into your stash.", Yard.shardsTakenCombo);
-            PassiveDialogueSystem.Instance.PushPassiveDialogue(entityID, message, 4, true);
+            PassiveDialogueSystem.Instance.PushPassiveDialogue(collectingYardID, message, 4, true);
         }
         else
         {
-            PassiveDialogueSystem.Instance.PushPassiveDialogue(entityID, "Your shard has been added into your stash.", 4, true);
+            PassiveDialogueSystem.Instance.PushPassiveDialogue(collectingYardID, "Your shard has been added into your stash.", 4, true);
         }
         Yard.shardsTakenCombo = 0;
     }

--- a/Assets/Scripts/Game Object Definitions/Entity Definitions/Yard.cs
+++ b/Assets/Scripts/Game Object Definitions/Entity Definitions/Yard.cs
@@ -38,8 +38,9 @@ public class Yard : AirConstruct, IShipBuilder
     }
 
     public static readonly int YardProximitySquared = 75;
-    private static float lastPartTakenTime = 0;
+    private static float lastPartTakenTime = 0, shardsTakenCombo = 0;
     private static int partsTakenCombo = 0;
+    public static string entityID;
 
     protected override void Update()
     {
@@ -62,44 +63,19 @@ public class Yard : AirConstruct, IShipBuilder
             // Notify the player that their parts have been collected
             if (Yard.partsTakenCombo > 0 && Time.time - Yard.lastPartTakenTime > 1)
             {
-                if (Yard.partsTakenCombo > 1)
+                if (Time.time - Yard.lastPartTakenTime > 1)
                 {
-                    string message = string.Format("<color=lime>Your {0} parts have been added into your inventory.</color>", Yard.partsTakenCombo);
-                    PassiveDialogueSystem.Instance.PushPassiveDialogue(GetComponent<Entity>().ID, message, 4);
+                    if (Yard.partsTakenCombo > 0)
+                    {
+                        PushPartCollectionDialogue();
+                    }
+                    if (Yard.shardsTakenCombo > 0)
+                    {
+                        PushShardCollectionDialogue();
+                    }
                 }
-                else
-                {
-                    PassiveDialogueSystem.Instance.PushPassiveDialogue(GetComponent<Entity>().ID, "<color=lime>Your part has been added into your inventory.</color>", 4);
-                }
-                Yard.partsTakenCombo = 0;
             }
         }
-    }
-
-    public static void TakePart(Entity entity, TractorBeam tractor)
-    {
-        if (entity as Yard)
-        {
-            // Waits to see if it will get more parts
-            Yard.lastPartTakenTime = Time.time;
-            Yard.partsTakenCombo++;
-        }
-        else
-        {
-            PassiveDialogueSystem.Instance.PushPassiveDialogue(entity.ID, "<color=lime>Your part has been added into your inventory.</color>", 4);
-        }
-        var shellPart = tractor.GetTractorTarget().GetComponent<ShellPart>();
-        var info = shellPart.info;
-        info = ShipBuilder.CullSpatialValues(info);
-        ShipBuilder.AddOriginToDictionary(shellPart);
-        PlayerCore.Instance.cursave.partInventory.Add(info);
-        PartIndexScript.AttemptAddToPartsObtained(info);
-        PartIndexScript.AttemptAddToPartsSeen(info);
-        if (NodeEditorFramework.Standard.YardCollectCondition.OnYardCollect != null)
-        {
-            NodeEditorFramework.Standard.YardCollectCondition.OnYardCollect.Invoke(info.partID, info.abilityID, shellPart.droppedSectorName);
-        }
-        Destroy(shellPart.gameObject);
     }
 
     private void GrabCollectiblesFromAllies()
@@ -222,5 +198,73 @@ public class Yard : AirConstruct, IShipBuilder
         {
             shellCore.HealToMax();
         }
+    }
+
+    public static void TakePart(Entity entity, TractorBeam tractor)
+    {
+        if (entity as Yard)
+        {
+            // Waits to see if it will get more parts
+            Yard.lastPartTakenTime = Time.time;
+            Yard.partsTakenCombo++;
+        }
+        entityID = entity.ID;
+        var shellPart = tractor.GetTractorTarget().GetComponent<ShellPart>();
+        var info = shellPart.info;
+        info = ShipBuilder.CullSpatialValues(info);
+        ShipBuilder.AddOriginToDictionary(shellPart);
+        PlayerCore.Instance.cursave.partInventory.Add(info);
+        PartIndexScript.AttemptAddToPartsObtained(info);
+        PartIndexScript.AttemptAddToPartsSeen(info);
+        if (NodeEditorFramework.Standard.YardCollectCondition.OnYardCollect != null)
+        {
+            NodeEditorFramework.Standard.YardCollectCondition.OnYardCollect.Invoke(info.partID, info.abilityID, shellPart.droppedSectorName);
+        }
+        Destroy(shellPart.gameObject);
+    }
+
+    public static void TakeShard(Entity entity, TractorBeam tractor)
+    {
+        entityID = entity.ID;
+
+        var shard = tractor.GetTractorTarget().GetComponent<Shard>();
+        var tiers = new int[] { 1, 5, 20 };
+        if (entity as Yard)
+        {
+            // Waits to see if it will get more parts
+            Yard.lastPartTakenTime = Time.time;
+            Yard.shardsTakenCombo += tiers[shard.tier];
+        }
+        PlayerCore.Instance.cursave.shards += tiers[shard.tier];
+        ShardCountScript();
+        Destroy(shard.gameObject);
+    }
+
+    private void PushPartCollectionDialogue()
+    {
+        if (Yard.partsTakenCombo > 1)
+        {
+            string message = string.Format("Your {0} parts have been added into your inventory.", Yard.partsTakenCombo);
+            PassiveDialogueSystem.Instance.PushPassiveDialogue(entityID, message, 4, true);
+        }
+        else
+        {
+            PassiveDialogueSystem.Instance.PushPassiveDialogue(entityID, "Your part has been added into your inventory.", 4, true);
+        }
+        Yard.partsTakenCombo = 0;
+    }
+
+    private void PushShardCollectionDialogue()
+    {
+        if (Yard.shardsTakenCombo > 1)
+        {
+            string message = string.Format("Your {0} shards have been added into your stash.", Yard.shardsTakenCombo);
+            PassiveDialogueSystem.Instance.PushPassiveDialogue(entityID, message, 4, true);
+        }
+        else
+        {
+            PassiveDialogueSystem.Instance.PushPassiveDialogue(entityID, "Your shard has been added into your stash.", 4, true);
+        }
+        Yard.shardsTakenCombo = 0;
     }
 }

--- a/Assets/Scripts/Game Object Definitions/Entity Definitions/Yard.cs
+++ b/Assets/Scripts/Game Object Definitions/Entity Definitions/Yard.cs
@@ -38,8 +38,8 @@ public class Yard : AirConstruct, IShipBuilder
     }
 
     public static readonly int YardProximitySquared = 75;
-    private static float lastPartTakenTime = 0, shardsTakenCombo = 0;
-    private static int partsTakenCombo = 0;
+    private static float lastPartTakenTime = 0;
+    private static int partsTakenCombo = 0, shardsTakenCombo = 0;
     public static string entityID;
 
     protected override void Update()

--- a/Assets/Scripts/Graphs/ConditionCheckNode.cs
+++ b/Assets/Scripts/Graphs/ConditionCheckNode.cs
@@ -249,10 +249,10 @@ namespace NodeEditorFramework.Standard
                         variableToCompare = PlayerCore.Instance.reputation;
                         break;
                     case 3:
-                        variableToCompare = PartIndexScript.GetNumberOfPartsSeen();
+                        variableToCompare = PartIndexScript.GetNumberOfPartsSeen(useBool);
                         break;
                     case 4:
-                        variableToCompare = PartIndexScript.GetNumberOfPartsObtained();
+                        variableToCompare = PartIndexScript.GetNumberOfPartsObtained(useBool);
                         break;
                     case 5:
                         return PlayerCore.Instance.cursave.missions.Exists(m => m.name == variableName) &&

--- a/Assets/Scripts/Graphs/ConditionCheckNode.cs
+++ b/Assets/Scripts/Graphs/ConditionCheckNode.cs
@@ -249,10 +249,10 @@ namespace NodeEditorFramework.Standard
                         variableToCompare = PlayerCore.Instance.reputation;
                         break;
                     case 3:
-                        variableToCompare = PartIndexScript.GetNumberOfPartsSeen(useBool);
+                        variableToCompare = PartIndexScript.GetNumberOfPartsSeen(inPercentage);
                         break;
                     case 4:
-                        variableToCompare = PartIndexScript.GetNumberOfPartsObtained(useBool);
+                        variableToCompare = PartIndexScript.GetNumberOfPartsObtained(inPercentage);
                         break;
                     case 5:
                         return PlayerCore.Instance.cursave.missions.Exists(m => m.name == variableName) &&

--- a/Assets/Scripts/HUD Scripts/QuantityDisplayScript.cs
+++ b/Assets/Scripts/HUD Scripts/QuantityDisplayScript.cs
@@ -157,10 +157,7 @@ public class QuantityDisplayScript : MonoBehaviour
             if (PartIndexScript.CheckPartObtained(info))
             {
                 targetName.text = info.partID;
-                if (info.abilityID == 10)
-                    targetDesc.text = AbilityUtilities.GetAbilityNameByID(info.abilityID, info.secondaryData);
-                else
-                    targetDesc.text = AbilityUtilities.GetAbilityNameByID(info.abilityID, null);
+                targetDesc.text = AbilityUtilities.GetAbilityNameByID(info.abilityID, info.secondaryData);
                 if (info.tier != 0)
                     targetDesc.text += " " + info.tier;
                 targetName.color = targetDesc.color = FactionManager.GetFactionColor(obj.GetComponent<ShellPart>().GetFaction());

--- a/Assets/Scripts/HUD Scripts/QuantityDisplayScript.cs
+++ b/Assets/Scripts/HUD Scripts/QuantityDisplayScript.cs
@@ -157,7 +157,12 @@ public class QuantityDisplayScript : MonoBehaviour
             if (PartIndexScript.CheckPartObtained(info))
             {
                 targetName.text = info.partID;
-                targetDesc.text = AbilityUtilities.GetAbilityNameByID(info.abilityID, null) + " " + info.tier;
+                if (info.abilityID == 10)
+                    targetDesc.text = AbilityUtilities.GetAbilityNameByID(info.abilityID, info.secondaryData);
+                else
+                    targetDesc.text = AbilityUtilities.GetAbilityNameByID(info.abilityID, null);
+                if (info.tier != 0)
+                    targetDesc.text += " " + info.tier;
                 targetName.color = targetDesc.color = FactionManager.GetFactionColor(obj.GetComponent<ShellPart>().GetFaction());
             }
             else
@@ -166,6 +171,21 @@ public class QuantityDisplayScript : MonoBehaviour
                 targetDesc.text = "Bring to Yard";
                 targetName.color = targetDesc.color = FactionManager.GetFactionColor(obj.GetComponent<ShellPart>().GetFaction());
             }
+        }
+        else if (obj.GetComponent<ShardRock>() || obj.GetComponent<Shard>())
+        {
+            if (obj.GetComponent<Shard>())
+            {
+                targetName.text = "Shard";
+                targetDesc.text = "Loot";
+            }
+            else
+            {
+                targetName.text = "Shard Rock";
+                targetDesc.text = "";
+            }
+            targetDesc.color = targetName.color = new Color32(51, 153, 204, 255);
+            targetInfo.SetActive(true);
         }
         else
         {

--- a/Assets/Scripts/HUD Scripts/SelectionBoxScript.cs
+++ b/Assets/Scripts/HUD Scripts/SelectionBoxScript.cs
@@ -133,6 +133,24 @@ public class SelectionBoxScript : MonoBehaviour
                 reticleScript.AddSecondaryTarget(part.transform);
             }
         }
+
+        foreach (var shards in AIData.shards)
+        {
+            if (shards.transform != PlayerCore.Instance.GetTargetingSystem().GetTarget()
+                                           && finalBox.Contains(shards.transform.position))
+            {
+                reticleScript.AddSecondaryTarget(shards.transform);
+            }
+        }
+
+        foreach (var fragments in AIData.rockFragments)
+        {
+            if (fragments.transform != PlayerCore.Instance.GetTargetingSystem().GetTarget()
+                                           && finalBox.Contains(fragments.transform.position))
+            {
+                reticleScript.AddSecondaryTarget(fragments.transform);
+            }
+        }
     }
 
     private void CycleTarget()

--- a/Assets/Scripts/PartIndexScript.cs
+++ b/Assets/Scripts/PartIndexScript.cs
@@ -34,9 +34,10 @@ public class PartIndexScript : MonoBehaviour
         Obtained
     }
 
-    public static int GetNumberOfPartsObtained()
+    public static int GetNumberOfPartsObtained(bool percentEnabled)
     {
         int count = 0;
+        int total = 0;
         foreach (var part in index)
         {
             var part2 = CullToPartIndexValues(part.part);
@@ -44,24 +45,33 @@ public class PartIndexScript : MonoBehaviour
             {
                 count++;
             }
+            total++;
         }
 
-        return count;
+        if (percentEnabled)
+            return (int)((count / (double)total) * 100);
+        else
+            return count;
     }
 
-    public static int GetNumberOfPartsSeen()
+    public static int GetNumberOfPartsSeen(bool percentEnabled)
     {
         int count = 0;
+        int total = 0;
         foreach (var part in index)
         {
             var part2 = CullToPartIndexValues(part.part);
-            if (CheckPartObtained(part2))
+            if (CheckPartSeen(part2))
             {
                 count++;
             }
+            total++;
         }
 
-        return count;
+        if (percentEnabled)
+            return (int)((count / (double)total) * 100);
+        else
+            return count;
     }
 
     public void SetPartAsSeen(EntityBlueprint.PartInfo part)


### PR DESCRIPTION
This is pretty much a fix related to parts and shards. Let me know if there are any issues with this.
- Fixed an issue where collecting parts/shards do not use the correct faction color or portrait.
- Reduce passive dialogue spam.
- Checking parts that are obtained/seen can be used as a percentage.
- Checking the amount of parts seen should work properly.
- Shards will now get deleted if it is not tractored by an entity or is not near the player.
- Players should be able to select multiple shards and shard rocks.
- Stray parts will no longer display tier 0 and will use secondary data for drone spawns.