### PR TITLE
Fix Aircraft Target AI on Tanks

### DIFF
--- a/Assets/Scripts/Game Object Definitions/AI/AirCraftAI.cs
+++ b/Assets/Scripts/Game Object Definitions/AI/AirCraftAI.cs
@@ -305,7 +305,8 @@ public class AirCraftAI : MonoBehaviour
             // shouldn't tick if dead or in cutscene, give control to the cutscene
             if (aggroTarget && !FactionManager.IsAllied(aggroTarget.faction, craft.faction) && !DialogueSystem.isInCutscene)
             {
-                if (aggroTarget.GetIsDead() || aggroTarget.IsInvisible)
+                if (aggroTarget.GetIsDead() || aggroTarget.IsInvisible ||
+                    aggroTarget.GetTerrain() == Entity.TerrainType.Ground && !(craft is Drone drone && drone.type == DroneType.Torpedo))
                 {
                     aggroTarget = null;
                     aggroSearchTimer = 0f;


### PR DESCRIPTION
Fixed an aircraft targeting issue with tanks. To explain this bug, if a ship tractors a tank in the air while entities are targeting it (the tank) but that ship later dies in any way and the tank lands on a platform, those entities will continue to target it.

There's room for improvement, but I have no idea at the moment.