### PR TITLE
Reworked Party Members

### DIFF
--- a/Assets/Scripts/Functional Definitions/Interaction Definitions/SectorManager.cs
+++ b/Assets/Scripts/Functional Definitions/Interaction Definitions/SectorManager.cs
@@ -285,6 +285,8 @@ public class SectorManager : MonoBehaviour
                 {
                     AttemptSectorLoad();
                     abortTimer = 6;
+
+                    PartyManager.instance.CheckParty();
                 }
             }
             else
@@ -1689,7 +1691,7 @@ public class SectorManager : MonoBehaviour
                     foreach (var ch in characters)
                     {
                         if (obj.Value.GetComponentInChildren<Entity>().ID == ch.ID && (
-                            lastSectorType == null ||
+                            lastSectorType == null || lastSectorType != overrideProperties.type ||
                             lastSectorType != Sector.SectorType.BattleZone ||
                             obj.Value.GetComponentInChildren<Entity>().faction.factionID == player.faction.factionID))
                         {

--- a/Assets/Scripts/Functional Definitions/Saving Scripts/PlayerSave.cs
+++ b/Assets/Scripts/Functional Definitions/Saving Scripts/PlayerSave.cs
@@ -63,10 +63,11 @@ public class PlayerSave
     // As well as for side missions to not change the episode number.
     public int episode;
 
-    // Contains IDs of unlocked party members (there will be a node that unlocks members adding IDs into this list)
+    public bool partyLock;
+    // The three lists contain IDs of unlocked, locked, and current party members
     public List<string> unlockedPartyIDs;
-    // Disabled party members. Saved so that EP3 persistent party locking does not need constant checkpoints
     public List<string> disabledPartyIDs;
+    public List<string> currentPartyMembers;
     public AbilityHotkeyStruct abilityHotkeys;
     public List<string> locationBasedShardsFound;
     public int lastDimension;

--- a/Assets/Scripts/Functional Definitions/Saving Scripts/SaveHandler.cs
+++ b/Assets/Scripts/Functional Definitions/Saving Scripts/SaveHandler.cs
@@ -92,6 +92,9 @@ public class SaveHandler : MonoBehaviour
             }
             if (MasterNetworkAdapter.mode == MasterNetworkAdapter.NetworkMode.Off)
                 StartCoroutine(Autobackup());
+
+            if (save.partyLock)
+                PartyManager.instance.SetOverrideLock(save.partyLock);
         }
         else
         {
@@ -103,6 +106,7 @@ public class SaveHandler : MonoBehaviour
             player.blueprint = GetDefaultBlueprint();
             player.abilityCaps = CoreUpgraderScript.minAbilityCap;
             player.cursave = save;
+            save.currentPartyMembers.Clear();
         }
     }
 
@@ -195,6 +199,8 @@ public class SaveHandler : MonoBehaviour
         playerSave.taskVariableNames = keys;
         playerSave.taskVariableValues = values;
         playerSave.reputation = player.reputation;
+
+        playerSave.partyLock = PartyManager.instance.GetOverrideLock();
     }
 
     public void Save()

--- a/Assets/Scripts/Game Object Definitions/Entity Definitions/PlayerCore.cs
+++ b/Assets/Scripts/Game Object Definitions/Entity Definitions/PlayerCore.cs
@@ -327,6 +327,15 @@ public class PlayerCore : ShellCore
 
         // the player needs a predictable name for task interactions, so its object will always be called this
         name = entityName = "player";
+
+        if (cursave.currentPartyMembers.Count > 0)
+        {
+            for (int i = 0; i < cursave.currentPartyMembers.Count; i++)
+            {
+                var partyMember = cursave.currentPartyMembers[i];
+                PartyManager.instance.AssignBackend(partyMember);
+            }
+        }
     }
 
     public override void Rebuild()

--- a/Assets/Scripts/Game Object Definitions/Entity Definitions/ShellCore.cs
+++ b/Assets/Scripts/Game Object Definitions/Entity Definitions/ShellCore.cs
@@ -280,7 +280,10 @@ public class ShellCore : AirCraft, IHarvester, IOwner
 
     public override void Respawn(bool force = false)
     {
-        if (force || (GetCarrier() != null && !GetCarrier().Equals(null)) || (this as PlayerCore && MasterNetworkAdapter.mode == NetworkMode.Off) || (PartyManager.instance && PartyManager.instance.partyMembers.Contains(this)))
+        bool hasCarrier = GetCarrier() != null && !GetCarrier().Equals(null);
+        if (force || hasCarrier || (this as PlayerCore && MasterNetworkAdapter.mode == NetworkMode.Off)
+            || (PartyManager.instance && PartyManager.instance.partyMembers.Contains(this)
+            && ((hasCarrier && sectorMngr.GetCurrentType() == Sector.SectorType.BattleZone) || (!hasCarrier && sectorMngr.GetCurrentType() != Sector.SectorType.BattleZone))))
         {
             if (this as PlayerCore) PlayerCore.Instance.enabled = true;
             isYardRepairing = false;

--- a/Assets/Scripts/HUD Scripts/SkirmishMenu.cs
+++ b/Assets/Scripts/HUD Scripts/SkirmishMenu.cs
@@ -99,7 +99,7 @@ public class SkirmishMenu : GUIWindowScripts
         }
 
         if (currentOption.clearParty)
-            PartyManager.instance.ClearParty(false);
+            PartyManager.instance.ClearParty(false, false);
         Flag.FindEntityAndWarpPlayer(currentOption.sectorName, currentOption.entityID);
         //Debug.LogError(PlayerCore.Instance.currentHealth[0]);
         CloseUI();


### PR DESCRIPTION
- Added party lock and party members to player's save file.
- Loading the game with party members should add them in.
- Party members will no longer respawn endlessly in BattleZones if your carrier was destroyed.
- Party members are reassigned back into the party whenever players leave an ongoing BattleZone or SiegeZone. This was more prominent when the party was locked and players couldn't reassign party members after getting deleted because of no respawn points, saving the game, or entering a skirmish mission.
- Characters shouldn't get deleted if the sector type had been changed.