### PR TITLE
Fix symmetry

### DIFF
--- a/Assets/Scripts/Functional Definitions/Blueprint Definitions/PartBlueprint.cs
+++ b/Assets/Scripts/Functional Definitions/Blueprint Definitions/PartBlueprint.cs
@@ -8,4 +8,13 @@ public class PartBlueprint : ScriptableObject
     public float mass;
     public int size;
     public bool detachible = true;
+    public PartSymmetry symmetry;
+}
+
+public enum PartSymmetry
+{
+    None,
+    MirrorXAxis,        // shape mirrored horizontally (up to down)
+    MirrorYAxis,        // shape mirrored vertically (left to right)
+    MirrorBothAxes      // all four corners are mirrored (180 degrees)
 }

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
@@ -638,39 +638,37 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
         part.rotation %= 360;
         symmetryPart.rotation %= 360;
         var partSymmetry = GetPartSymmetry(part.partID);
+        var diff = Mathf.Abs(part.rotation + symmetryPart.rotation);
 
+        // Note: There are cases where the parts are symmetrically aligned for both same-mirror and opposite-mirror pairs
         switch (partSymmetry)
         {
             case PartSymmetry.MirrorXAxis:
-                // There are cases where the parts are symmetrically aligned for both same-mirror and opposite-mirror pairs
-                var diff = Mathf.Abs(part.rotation + symmetryPart.rotation);
                 if (symmetryMode == SymmetryMode.Y)
                 {
                     if (part.mirrored == symmetryPart.mirrored)
                         return diff % 360 == 0;
-                    else
-                        return diff % 360 == 180;
+
+                    return diff % 360 == 180;
                 }
 
                 if (part.mirrored != symmetryPart.mirrored)
-                {
                     return diff % 360 == 0;
-                }
 
                 return diff % 360 == 180;
             case PartSymmetry.MirrorYAxis:
                 if (symmetryMode == SymmetryMode.X)
-                {
-                    return part.mirrored != symmetryPart.mirrored && ((part.rotation + symmetryPart.rotation) % 360 == 0);
-                }
+                    return part.mirrored != symmetryPart.mirrored && diff % 360 == 0;
 
-                diff = Mathf.Abs(part.rotation + symmetryPart.rotation);
                 return diff % 360 == 180;
             case PartSymmetry.MirrorBothAxes:
-                return (part.rotation + symmetryPart.rotation) % 360 == 0;
+                return diff % 360 == 0 || diff % 360 == 180;
             case PartSymmetry.None:
             default:
-                return part.mirrored != symmetryPart.mirrored && ((part.rotation + symmetryPart.rotation) % 360 == 0);
+                if (symmetryMode == SymmetryMode.Y)
+                    return part.mirrored != symmetryPart.mirrored && diff % 360 == 180;
+
+                return part.mirrored != symmetryPart.mirrored && diff % 360 == 0;
         }
     }
 

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
@@ -639,7 +639,7 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
 
                 return diff % 360 == 180;
             case PartSymmetry.MirrorBothAxes:
-                return diff % 360 == 0 || diff % 360 == 180;
+                return diff % 180 == 0;
             case PartSymmetry.None:
             default:
                 if (symmetryMode == SymmetryMode.Y)

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
@@ -603,33 +603,10 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
         return (vec1 - vec2).sqrMagnitude <= ShipBuilderCursorScript.stepSize;
     }
 
-    private enum PartSymmetry
-    {
-        None,
-        MirrorXAxis,
-        MirrorYAxis,
-        MirrorBothAxes
-    }
-
-    // Hardcodes axial symmetry for specific part IDs
+    // Check axial symmetry using part ID
     private static PartSymmetry GetPartSymmetry(string partID)
     {
-        switch (partID)
-        {
-            case "SmallSide1":
-            case "SmallSide3":
-            case "SmallSide4":
-            case "MediumSide2":
-                return PartSymmetry.MirrorXAxis;
-            case "MediumExtra1":
-            case "MediumCenter4":
-                return PartSymmetry.MirrorYAxis;
-            case "SmallSide2":
-                return PartSymmetry.MirrorBothAxes;
-            default:
-                if (partID.Contains("Center")) return PartSymmetry.MirrorYAxis;
-                return PartSymmetry.None;
-        }
+        return ResourceManager.GetAsset<PartBlueprint>(partID).symmetry;
     }
 
     // Checks the orientation of the part.

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
@@ -583,9 +583,9 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
                     continue;
                 }
             }
-            if ((!symmetryPart || (parts[i].info.partID == symmetryPart.info.partID &&
-                (symmetryMode != SymmetryMode.X
-                    || CheckOrientationCompatibility(parts[i].info, symmetryPart.info)))))
+            
+            if (!symmetryPart || (parts[i].info.partID == symmetryPart.info.partID)
+                && (symmetryMode == SymmetryMode.Off || CheckOrientationCompatibility(parts[i].info, symmetryPart.info)))
             {
                 transform.position = origPos;
                 return parts[i];
@@ -632,25 +632,42 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
         }
     }
 
-    // Currently only does something for X-axis checks.
+    // Checks the orientation of the part.
     private bool CheckOrientationCompatibility(EntityBlueprint.PartInfo part, EntityBlueprint.PartInfo symmetryPart)
     {
-        var partID = part.partID;
         part.rotation %= 360;
         symmetryPart.rotation %= 360;
-        switch (GetPartSymmetry(part.partID))
+        var partSymmetry = GetPartSymmetry(part.partID);
+
+        switch (partSymmetry)
         {
-            case PartSymmetry.MirrorYAxis:
-            case PartSymmetry.MirrorBothAxes:
-                return (part.rotation + symmetryPart.rotation) % 360 == 0;
             case PartSymmetry.MirrorXAxis:
                 // There are cases where the parts are symmetrically aligned for both same-mirror and opposite-mirror pairs
                 var diff = Mathf.Abs(part.rotation + symmetryPart.rotation);
+                if (symmetryMode == SymmetryMode.Y)
+                {
+                    if (part.mirrored == symmetryPart.mirrored)
+                        return diff % 360 == 0;
+                    else
+                        return diff % 360 == 180;
+                }
+
                 if (part.mirrored != symmetryPart.mirrored)
                 {
                     return diff % 360 == 0;
                 }
+
                 return diff % 360 == 180;
+            case PartSymmetry.MirrorYAxis:
+                if (symmetryMode == SymmetryMode.X)
+                {
+                    return part.mirrored != symmetryPart.mirrored && ((part.rotation + symmetryPart.rotation) % 360 == 0);
+                }
+
+                diff = Mathf.Abs(part.rotation + symmetryPart.rotation);
+                return diff % 360 == 180;
+            case PartSymmetry.MirrorBothAxes:
+                return (part.rotation + symmetryPart.rotation) % 360 == 0;
             case PartSymmetry.None:
             default:
                 return part.mirrored != symmetryPart.mirrored && ((part.rotation + symmetryPart.rotation) % 360 == 0);

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderCursorScript.cs
@@ -339,7 +339,7 @@ public class ShipBuilderCursorScript : MonoBehaviour, IShipStatsDatabase
         lastPart.info.mirrored = !lastPart.info.mirrored;
         if (symmetryLastPart)
         {
-            symmetryLastPart.info.mirrored = !lastPart.info.mirrored;
+            symmetryLastPart.info.mirrored = !symmetryLastPart.info.mirrored;
         }
 
         flipped = true;

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderInventoryScript.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderInventoryScript.cs
@@ -115,11 +115,16 @@ public class ShipBuilderInventoryScript : ShipBuilderInventoryBase
         ShipBuilderPart symmetryPart = count >= minCount && cursor.symmetryMode != ShipBuilderCursorScript.SymmetryMode.Off ? InstantiatePart() : null;
         if (symmetryPart)
         {
-            //if(cursor.symmetryMode == ShipBuilderCursorScript.SymmetryMode.X)
-            symmetryPart.info.mirrored = !builderPart.info.mirrored;
-            if (cursor.symmetryMode == ShipBuilderCursorScript.SymmetryMode.Y)
+
+            switch (cursor.symmetryMode)
             {
-                symmetryPart.info.rotation = 180;
+                case ShipBuilderCursorScript.SymmetryMode.X:
+                    symmetryPart.info.mirrored = !builderPart.info.mirrored;
+                    break;
+                case ShipBuilderCursorScript.SymmetryMode.Y:
+                    symmetryPart.info.rotation = 180;
+                    symmetryPart.info.mirrored = !builderPart.info.mirrored;
+                    break;
             }
         }
 

--- a/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderPart.cs
+++ b/Assets/Scripts/HUD Scripts/Ship Builder Scripts/ShipBuilderPart.cs
@@ -104,11 +104,13 @@ public class ShipBuilderPart : DisplayPart, IPointerEnterHandler, IPointerExitHa
                     if (cursorScript.symmetryMode == ShipBuilderCursorScript.SymmetryMode.X)
                     {
                         onAxis = Mathf.Abs(rectTransform.anchoredPosition.y) < ShipBuilderCursorScript.stepSize;
+                        onAxis = Mathf.Abs(rectTransform.anchoredPosition.x) < ShipBuilderCursorScript.stepSize;
                     }
 
-                    if (cursorScript.symmetryMode == ShipBuilderCursorScript.SymmetryMode.X)
+                    if (cursorScript.symmetryMode == ShipBuilderCursorScript.SymmetryMode.Y)  // need some fixing
                     {
                         onAxis = Mathf.Abs(rectTransform.anchoredPosition.x) < ShipBuilderCursorScript.stepSize;
+                        onAxis = Mathf.Abs(rectTransform.anchoredPosition.y) < ShipBuilderCursorScript.stepSize;
                     }
 
                     if ((!symmetryPart || (symmetryPart.rectTransform.anchoredPosition - symVec).sqrMagnitude >

--- a/Assets/StreamingAssets/Parts/BigCenter1.json
+++ b/Assets/StreamingAssets/Parts/BigCenter1.json
@@ -1,1 +1,1 @@
-{"spriteID":"BigCenter1_sprite","health":2500.0,"mass":0.8,"size":2}
+{"spriteID":"BigCenter1_sprite","health":2500.0,"mass":0.8,"size":2,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/BigCenter2.json
+++ b/Assets/StreamingAssets/Parts/BigCenter2.json
@@ -1,1 +1,1 @@
-{"spriteID":"BigCenter2_sprite","health":2500.0,"mass":0.8,"size":2}
+{"spriteID":"BigCenter2_sprite","health":2500.0,"mass":0.8,"size":2,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/BigCenter3.json
+++ b/Assets/StreamingAssets/Parts/BigCenter3.json
@@ -1,1 +1,1 @@
-{"spriteID":"BigCenter3_sprite","health":2500.0,"mass":0.8,"size":2}
+{"spriteID":"BigCenter3_sprite","health":2500.0,"mass":0.8,"size":2,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/BigCenter4.json
+++ b/Assets/StreamingAssets/Parts/BigCenter4.json
@@ -1,1 +1,1 @@
-{"spriteID":"BigCenter4_sprite","health":2500.0,"mass":0.8,"size":2}
+{"spriteID":"BigCenter4_sprite","health":2500.0,"mass":0.8,"size":2,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/MediumCenter1.json
+++ b/Assets/StreamingAssets/Parts/MediumCenter1.json
@@ -1,1 +1,1 @@
-{"spriteID":"MediumCenter1_sprite","health":1200.0,"mass":0.4,"size":1}
+{"spriteID":"MediumCenter1_sprite","health":1200.0,"mass":0.4,"size":1,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/MediumCenter2.json
+++ b/Assets/StreamingAssets/Parts/MediumCenter2.json
@@ -1,1 +1,1 @@
-{"spriteID":"MediumCenter2_sprite","health":1200.0,"mass":0.4,"size":1}
+{"spriteID":"MediumCenter2_sprite","health":1200.0,"mass":0.4,"size":1,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/MediumCenter3.json
+++ b/Assets/StreamingAssets/Parts/MediumCenter3.json
@@ -1,1 +1,1 @@
-{"spriteID":"MediumCenter3_sprite","health":1200.0,"mass":0.4,"size":1}
+{"spriteID":"MediumCenter3_sprite","health":1200.0,"mass":0.4,"size":1,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/MediumCenter4.json
+++ b/Assets/StreamingAssets/Parts/MediumCenter4.json
@@ -1,1 +1,1 @@
-{"spriteID":"MediumCenter4_sprite","health":1200.0,"mass":0.4,"size":1}
+{"spriteID":"MediumCenter4_sprite","health":1200.0,"mass":0.4,"size":1,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/MediumCenter5.json
+++ b/Assets/StreamingAssets/Parts/MediumCenter5.json
@@ -1,1 +1,1 @@
-{"spriteID":"MediumCenter5_sprite","health":1200.0,"mass":0.4,"size":1}
+{"spriteID":"MediumCenter5_sprite","health":1200.0,"mass":0.4,"size":1,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/MediumCenter6.json
+++ b/Assets/StreamingAssets/Parts/MediumCenter6.json
@@ -1,1 +1,1 @@
-{"spriteID":"MediumCenter6_sprite","health":1200.0,"mass":0.4,"size":1}
+{"spriteID":"MediumCenter6_sprite","health":1200.0,"mass":0.4,"size":1,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/MediumCenter7.json
+++ b/Assets/StreamingAssets/Parts/MediumCenter7.json
@@ -1,1 +1,1 @@
-{"spriteID":"MediumCenter7_sprite","health":1000.0,"mass":0.36,"size":1}
+{"spriteID":"MediumCenter7_sprite","health":1000.0,"mass":0.36,"size":1,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/MediumExtra1.json
+++ b/Assets/StreamingAssets/Parts/MediumExtra1.json
@@ -1,1 +1,1 @@
-{"spriteID":"MediumExtra1_sprite","health":1200.0,"mass":0.4,"size":1}
+{"spriteID":"MediumExtra1_sprite","health":1200.0,"mass":0.4,"size":1,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/MediumSide2.json
+++ b/Assets/StreamingAssets/Parts/MediumSide2.json
@@ -1,1 +1,1 @@
-{"spriteID":"MediumSide2_sprite","health":1200.0,"mass":0.4,"size":1}
+{"spriteID":"MediumSide2_sprite","health":1200.0,"mass":0.4,"size":1,"symmetry":1}

--- a/Assets/StreamingAssets/Parts/SmallCenter1.json
+++ b/Assets/StreamingAssets/Parts/SmallCenter1.json
@@ -1,1 +1,1 @@
-{"spriteID":"SmallCenter1_sprite","health":200.0,"mass":0.08,"size":0}
+{"spriteID":"SmallCenter1_sprite","health":200.0,"mass":0.08,"size":0,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/SmallCenter2.json
+++ b/Assets/StreamingAssets/Parts/SmallCenter2.json
@@ -1,1 +1,1 @@
-{"spriteID":"SmallCenter2_sprite","health":500.0,"mass":0.2,"size":0,"size":0}
+{"spriteID":"SmallCenter2_sprite","health":500.0,"mass":0.2,"size":0,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/SmallCenter3.json
+++ b/Assets/StreamingAssets/Parts/SmallCenter3.json
@@ -1,1 +1,1 @@
-{"spriteID":"SmallCenter3_sprite","health":500.0,"mass":0.2,"size":0}
+{"spriteID":"SmallCenter3_sprite","health":500.0,"mass":0.2,"size":0,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/SmallCenter4.json
+++ b/Assets/StreamingAssets/Parts/SmallCenter4.json
@@ -1,1 +1,1 @@
-{"spriteID":"SmallCenter4_sprite","health":400.0,"mass":0.16,"size":0}
+{"spriteID":"SmallCenter4_sprite","health":400.0,"mass":0.16,"size":0,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/SmallCenter5.json
+++ b/Assets/StreamingAssets/Parts/SmallCenter5.json
@@ -1,1 +1,1 @@
-{"spriteID":"SmallCenter5_sprite","health":500.0,"mass":0.2,"size":0}
+{"spriteID":"SmallCenter5_sprite","health":500.0,"mass":0.2,"size":0,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/SmallCenter6.json
+++ b/Assets/StreamingAssets/Parts/SmallCenter6.json
@@ -1,1 +1,1 @@
-{"spriteID":"SmallCenter6_sprite","health":500.0,"mass":0.2,"size":0,"symmetry":2}
+{"spriteID":"SmallCenter6_sprite","health":500.0,"mass":0.2,"size":0,"symmetry":3}

--- a/Assets/StreamingAssets/Parts/SmallCenter6.json
+++ b/Assets/StreamingAssets/Parts/SmallCenter6.json
@@ -1,1 +1,1 @@
-{"spriteID":"SmallCenter6_sprite","health":500.0,"mass":0.2,"size":0}
+{"spriteID":"SmallCenter6_sprite","health":500.0,"mass":0.2,"size":0,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/SmallCenter7.json
+++ b/Assets/StreamingAssets/Parts/SmallCenter7.json
@@ -1,1 +1,1 @@
-{"spriteID":"SmallCenter7_sprite","health":500.0,"mass":0.2,"size":0}
+{"spriteID":"SmallCenter7_sprite","health":500.0,"mass":0.2,"size":0,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/SmallCenter8.json
+++ b/Assets/StreamingAssets/Parts/SmallCenter8.json
@@ -1,1 +1,1 @@
-{"spriteID":"SmallCenter8_sprite","health":500.0,"mass":0.2,"size":0}
+{"spriteID":"SmallCenter8_sprite","health":500.0,"mass":0.2,"size":0,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/SmallCenter9.json
+++ b/Assets/StreamingAssets/Parts/SmallCenter9.json
@@ -1,1 +1,1 @@
-{"spriteID":"SmallCenter9_sprite","health":500.0,"mass":0.2,"size":0}
+{"spriteID":"SmallCenter9_sprite","health":500.0,"mass":0.2,"size":0,"symmetry":2}

--- a/Assets/StreamingAssets/Parts/SmallSide1.json
+++ b/Assets/StreamingAssets/Parts/SmallSide1.json
@@ -1,1 +1,1 @@
-{"spriteID":"SmallSide1_sprite","health":300.0,"mass":0.12,"size":0}
+{"spriteID":"SmallSide1_sprite","health":300.0,"mass":0.12,"size":0,"symmetry":1}

--- a/Assets/StreamingAssets/Parts/SmallSide2.json
+++ b/Assets/StreamingAssets/Parts/SmallSide2.json
@@ -1,1 +1,1 @@
-{"spriteID":"SmallSide2_sprite","health":500.0,"mass":0.2,"size":0}
+{"spriteID":"SmallSide2_sprite","health":500.0,"mass":0.2,"size":0,"symmetry":3}

--- a/Assets/StreamingAssets/Parts/SmallSide3.json
+++ b/Assets/StreamingAssets/Parts/SmallSide3.json
@@ -1,1 +1,1 @@
-{"spriteID":"SmallSide3_sprite","health":200.0,"mass":0.08,"size":0}
+{"spriteID":"SmallSide3_sprite","health":200.0,"mass":0.08,"size":0,"symmetry":1}

--- a/Assets/StreamingAssets/Parts/SmallSide4.json
+++ b/Assets/StreamingAssets/Parts/SmallSide4.json
@@ -1,1 +1,1 @@
-{"spriteID":"SmallSide4_sprite","health":400.0,"mass":0.16,"size":0}
+{"spriteID":"SmallSide4_sprite","health":400.0,"mass":0.16,"size":0,"symmetry":1}


### PR DESCRIPTION
- Fix symmetry with parts that are mirrored on the y-axis
- Attempted to fix symmetry issues that are mirrored on either axis and placed along the other axis.
- Fix unsync mirroring.
- Fix symmetry for parts that are not symmetrical and parts that are symmetrical on both axes.
- Removed hard coded part symmetry. Parts blueprints now store the symmetry.