### PR TITLE
Fix invert tractor and saving worlds

### DIFF
--- a/Assets/Scripts/Functional Definitions/Abilities/InvertTractor.cs
+++ b/Assets/Scripts/Functional Definitions/Abilities/InvertTractor.cs
@@ -24,8 +24,8 @@ public class InvertTractor : ActiveAbility
     /// </summary>
     public override void Deactivate()
     {
-        Core.invertTractors--;
         if (Core is ShellCore core && !MasterNetworkAdapter.lettingServerDecide) core.SetTractorTarget(null);
+        Core.invertTractors--;
         base.Deactivate();
     }
 

--- a/Assets/Scripts/Functional Definitions/Interaction Definitions/TractorBeam.cs
+++ b/Assets/Scripts/Functional Definitions/Interaction Definitions/TractorBeam.cs
@@ -262,7 +262,7 @@ public class TractorBeam : MonoBehaviour
                 lineRenderer.enabled = (newTarget != null);
             }
             
-            if (target && (!owner.isTractorSwitched || !target.GetComponent<Entity>()))
+            if (target && (owner.isTractorSwitched || !target.GetComponent<Entity>()))
             {
                 target.RemoveDrag();
             }

--- a/Assets/Scripts/Functional Definitions/Interaction Definitions/TractorBeam.cs
+++ b/Assets/Scripts/Functional Definitions/Interaction Definitions/TractorBeam.cs
@@ -262,7 +262,7 @@ public class TractorBeam : MonoBehaviour
                 lineRenderer.enabled = (newTarget != null);
             }
             
-            if (target && (owner.isTractorSwitched || !target.GetComponent<Entity>()))
+            if (target && (!owner.isTractorSwitched || !target.GetComponent<Entity>()))
             {
                 target.RemoveDrag();
             }

--- a/Assets/World Creator Assets/Scripts/WCGeneratorHandler.cs
+++ b/Assets/World Creator Assets/Scripts/WCGeneratorHandler.cs
@@ -557,6 +557,12 @@ public class WCGeneratorHandler : MonoBehaviour
             lines.Add("factions:");
             foreach (var faction in factionManager.factions)
             {
+                // avoid default factions
+                if (FactionManager.defaultFactions.Contains(faction))
+                {
+                    continue;
+                }
+
                 if (faction == null)
                     continue;
 


### PR DESCRIPTION
- Fix invert tractor again. It should not cause draggable objects from getting stuck on one axis again.
- Reverted the commit that removed checking for default factions when saving worlds.